### PR TITLE
test(e2e): keep lifecycle sandboxes running

### DIFF
--- a/e2e/policy-advisor/mechanistic-smoke.sh
+++ b/e2e/policy-advisor/mechanistic-smoke.sh
@@ -76,9 +76,10 @@ create_sandbox() {
     "$OPENSHELL_BIN" sandbox delete "$SANDBOX" >/dev/null 2>&1 || true
     "$OPENSHELL_BIN" sandbox create \
         --name "$SANDBOX" \
+        --detach \
         --no-auto-providers \
         --no-tty \
-        -- bash -lc "echo sandbox ready" \
+        -- sh -c "exec sleep infinity" \
         | sed 's/^/  /'
 
     "$OPENSHELL_BIN" sandbox ssh-config "$SANDBOX" > "$SSH_CONFIG"
@@ -101,14 +102,20 @@ trigger_l4_deny() {
 }
 
 assert_pending_chunk() {
-    step "Waiting ${FLUSH_WAIT}s then checking for pending chunk"
-    sleep "$FLUSH_WAIT"
-    local output
-    output="$("$OPENSHELL_BIN" rule get "$SANDBOX" --status pending 2>&1)"
+    step "Waiting up to ${FLUSH_WAIT}s for pending chunk"
+    local output=""
+    local _i
+    for _i in $(seq 1 "$FLUSH_WAIT"); do
+        output="$("$OPENSHELL_BIN" rule get "$SANDBOX" --status pending 2>&1)"
+        if printf '%s\n' "$output" | grep -qi "blocked.invalid"; then
+            printf '%s\n' "$output" | sed 's/^/  /'
+            ok "pending mechanistic chunk present for blocked.invalid"
+            return
+        fi
+        sleep 1
+    done
     printf '%s\n' "$output" | sed 's/^/  /'
-    printf '%s\n' "$output" | grep -qi "blocked.invalid" \
-        || fail "no pending chunk for blocked.invalid"
-    ok "pending mechanistic chunk present for blocked.invalid"
+    fail "no pending chunk for blocked.invalid after ${FLUSH_WAIT}s"
 }
 
 main() {

--- a/e2e/policy-advisor/test.sh
+++ b/e2e/policy-advisor/test.sh
@@ -230,9 +230,7 @@ create_sandbox() {
         --policy "$POLICY_FILE" \
         --upload "${RUNNER_SOURCE}:/sandbox/policy-validation-runner.sh" \
         --no-git-ignore \
-        --no-auto-providers \
-        --no-tty \
-        -- bash -lc "chmod +x /sandbox/policy-validation-runner.sh && echo sandbox ready"
+        --no-auto-providers
 }
 
 connect_ssh() {
@@ -245,6 +243,8 @@ connect_ssh() {
     local i
     for i in $(seq 1 "$retries"); do
         if ssh -F "$SSH_CONFIG" "$SSH_HOST" true >/dev/null 2>&1; then
+            ssh -F "$SSH_CONFIG" "$SSH_HOST" chmod +x /sandbox/policy-validation-runner.sh \
+                || fail "could not make uploaded policy runner executable"
             return
         fi
         sleep 2

--- a/e2e/policy-advisor/wait-smoke.sh
+++ b/e2e/policy-advisor/wait-smoke.sh
@@ -129,8 +129,6 @@ create_sandbox() {
         --upload "${RUNNER_SOURCE}:/sandbox/runner.sh" \
         --no-git-ignore \
         --no-auto-providers \
-        --no-tty \
-        -- bash -lc "chmod +x /sandbox/runner.sh && echo sandbox ready" \
         | sed 's/^/  /'
 
     "$OPENSHELL_BIN" sandbox ssh-config "$SANDBOX" > "$SSH_CONFIG"
@@ -140,6 +138,8 @@ create_sandbox() {
     local _i
     for _i in $(seq 1 30); do
         if ssh -F "$SSH_CONFIG" "$SSH_HOST" true >/dev/null 2>&1; then
+            ssh -F "$SSH_CONFIG" "$SSH_HOST" chmod +x /sandbox/runner.sh \
+                || fail "could not make uploaded runner executable"
             ok "SSH up"
             return
         fi

--- a/e2e/rust/src/harness/sandbox.rs
+++ b/e2e/rust/src/harness/sandbox.rs
@@ -51,6 +51,16 @@ pub struct SandboxGuard {
 }
 
 impl SandboxGuard {
+    /// Manage the cleanup of a sandbox created outside this helper.
+    pub fn manage_existing(name: String) -> Self {
+        Self {
+            name,
+            create_output: String::new(),
+            child: None,
+            cleaned_up: false,
+        }
+    }
+
     /// Create a persistent scratch sandbox and optionally run a command in it.
     ///
     /// Arguments before `--` are forwarded to `sandbox create`; arguments after
@@ -73,14 +83,17 @@ impl SandboxGuard {
             (&args[..index], &args[index + 1..])
         });
 
+        if create_args.contains(&"--no-keep") {
+            return Err(
+                "SandboxGuard::create makes a persistent scratch sandbox; use the CLI directly to test --no-keep semantics"
+                    .to_string(),
+            );
+        }
+
         let mut cmd = openshell_cmd();
         cmd.arg("sandbox").arg("create").arg("--detach");
         for arg in create_args {
-            // `--no-keep` described the old disposable-exec create flow and
-            // conflicts with the detached scratch sandbox used by this helper.
-            if *arg != "--no-keep" {
-                cmd.arg(arg);
-            }
+            cmd.arg(arg);
         }
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 

--- a/e2e/rust/tests/credential_drivers.rs
+++ b/e2e/rust/tests/credential_drivers.rs
@@ -246,7 +246,6 @@ async fn assert_provider_placeholder_available_in_sandbox(
         sandbox_name,
         "--provider",
         provider_name,
-        "--no-keep",
         "--no-auto-providers",
         "--no-tty",
         "--",

--- a/e2e/rust/tests/driver_config_volume.rs
+++ b/e2e/rust/tests/driver_config_volume.rs
@@ -145,7 +145,6 @@ async fn sandbox_mounts_existing_driver_config_volume() {
         volume.name
     );
     let mut sandbox = SandboxGuard::create(&[
-        "--no-keep",
         "--driver-config-json",
         &driver_config,
         "--",
@@ -269,7 +268,6 @@ async fn sandbox_mounts_enabled_driver_config_bind() {
     let policy = write_bind_mount_policy().expect("write bind mount policy");
     let policy_path = policy.path().to_str().expect("policy path must be utf-8");
     let mut sandbox = SandboxGuard::create(&[
-        "--no-keep",
         "--policy",
         policy_path,
         "--driver-config-json",

--- a/e2e/rust/tests/gpu/workloads.rs
+++ b/e2e/rust/tests/gpu/workloads.rs
@@ -7,7 +7,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use openshell_e2e::harness::output::strip_ansi;
+use openshell_e2e::harness::cli::{run_cli, wait_for_sandbox_phase};
+use openshell_e2e::harness::output::{extract_field, strip_ansi};
 use openshell_e2e::harness::sandbox::SandboxGuard;
 use serde::Deserialize;
 use serial_test::serial;
@@ -17,6 +18,7 @@ const WORKLOAD_MANIFEST_ENV: &str = "OPENSHELL_E2E_WORKLOAD_MANIFEST";
 const GPU_WORKLOAD_SUCCESS_MARKER: &str = "OPENSHELL_GPU_WORKLOAD_SUCCESS";
 const GPU_WORKLOAD_FAILURE_MARKER: &str = "OPENSHELL_GPU_WORKLOAD_FAILURE";
 const WORKLOAD_SANDBOX_CREATE_TIMEOUT: Duration = Duration::from_secs(600);
+const WORKLOAD_PHASE_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Deserialize)]
 struct WorkloadManifest {
@@ -92,75 +94,119 @@ fn load_workload_manifest() -> Option<WorkloadManifest> {
     Some(manifest)
 }
 
-async fn create_workload_sandbox(args: &[&str]) -> Result<SandboxGuard, String> {
-    timeout(WORKLOAD_SANDBOX_CREATE_TIMEOUT, SandboxGuard::create(args))
+struct WorkloadRun {
+    guard: SandboxGuard,
+    output: String,
+    exit_code: i32,
+}
+
+async fn run_workload(workload: &WorkloadDefinition) -> Result<WorkloadRun, String> {
+    let mut args = vec![
+        "sandbox".to_string(),
+        "create".to_string(),
+        "--gpu".to_string(),
+        "--from".to_string(),
+        workload.image.clone(),
+        "--".to_string(),
+    ];
+    args.extend(workload.command.clone());
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+
+    let (output, exit_code) = timeout(WORKLOAD_SANDBOX_CREATE_TIMEOUT, run_cli(&arg_refs))
         .await
         .map_err(|_| {
             format!(
                 "GPU workload sandbox create timed out after {WORKLOAD_SANDBOX_CREATE_TIMEOUT:?}"
             )
-        })?
+        })?;
+    let clean_output = strip_ansi(&output);
+    let sandbox_name = extract_field(&clean_output, "Created sandbox")
+        .or_else(|| extract_field(&clean_output, "Name"))
+        .ok_or_else(|| {
+            format!("could not parse sandbox name from create output:\n{clean_output}")
+        })?;
+
+    Ok(WorkloadRun {
+        guard: SandboxGuard::manage_existing(sandbox_name),
+        output: clean_output,
+        exit_code,
+    })
 }
 
 async fn assert_expected_pass(workload: &WorkloadDefinition) {
-    let mut args = vec![
-        "--gpu".to_string(),
-        "--from".to_string(),
-        workload.image.clone(),
-        "--".to_string(),
-    ];
-    args.extend(workload.command.clone());
-    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut run = run_workload(workload).await.unwrap_or_else(|err| {
+        panic!(
+            "GPU workload '{}' expected success but sandbox create failed:\n{err}",
+            workload.name
+        )
+    });
 
-    let mut guard = create_workload_sandbox(&arg_refs)
+    assert_eq!(
+        run.exit_code, 0,
+        "GPU workload '{}' expected success. Output:\n{}",
+        workload.name, run.output
+    );
+    wait_for_sandbox_phase(&run.guard.name, "Completed", WORKLOAD_PHASE_TIMEOUT)
         .await
         .unwrap_or_else(|err| {
             panic!(
-                "GPU workload '{}' expected success but sandbox create failed:\n{err}",
+                "GPU workload '{}' did not retain Completed status:\n{err}",
                 workload.name
             )
         });
 
-    let clean_output = strip_ansi(&guard.create_output);
-    guard.cleanup().await;
-
     assert!(
-        clean_output.contains(GPU_WORKLOAD_SUCCESS_MARKER),
-        "expected success marker {GPU_WORKLOAD_SUCCESS_MARKER} for workload '{}' image {} in sandbox output:\n{clean_output}",
+        run.output.contains(GPU_WORKLOAD_SUCCESS_MARKER),
+        "expected success marker {GPU_WORKLOAD_SUCCESS_MARKER} for workload '{}' image {} in sandbox output:\n{}",
         workload.name,
         workload.image,
+        run.output,
     );
+    run.guard.cleanup().await;
 }
 
 async fn assert_expected_fail(workload: &WorkloadDefinition) {
-    let mut args = vec![
-        "--gpu".to_string(),
-        "--from".to_string(),
-        workload.image.clone(),
-        "--".to_string(),
-    ];
-    args.extend(workload.command.clone());
-    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut run = run_workload(workload).await.unwrap_or_else(|err| {
+        panic!(
+            "GPU workload '{}' could not be started:\n{err}",
+            workload.name
+        )
+    });
 
-    match create_workload_sandbox(&arg_refs).await {
-        Ok(mut guard) => {
-            let clean_output = strip_ansi(&guard.create_output);
-            guard.cleanup().await;
+    assert_ne!(
+        run.exit_code, 0,
+        "GPU workload '{}' unexpectedly succeeded. Output:\n{}",
+        workload.name, run.output
+    );
+    wait_for_sandbox_phase(&run.guard.name, "Error", WORKLOAD_PHASE_TIMEOUT)
+        .await
+        .unwrap_or_else(|err| {
             panic!(
-                "GPU workload '{}' unexpectedly succeeded. Output:\n{clean_output}",
+                "GPU workload '{}' did not retain Error status:\n{err}",
                 workload.name
-            );
-        }
-        Err(err) => {
-            let clean_output = strip_ansi(&err);
-            assert!(
-                clean_output.contains(GPU_WORKLOAD_FAILURE_MARKER),
-                "expected failure marker {GPU_WORKLOAD_FAILURE_MARKER} for workload '{}' image {} in failure output:\n{clean_output}",
-                workload.name,
-                workload.image,
-            );
-        }
-    }
+            )
+        });
+    let (details, get_exit_code) = run_cli(&["sandbox", "get", &run.guard.name]).await;
+    let clean_details = strip_ansi(&details);
+    assert_eq!(
+        get_exit_code, 0,
+        "could not inspect failed GPU workload '{}':\n{clean_details}",
+        workload.name
+    );
+    assert!(
+        clean_details.contains(&format!("Exit Code: {}", run.exit_code)),
+        "failed GPU workload '{}' did not retain exit code {}:\n{clean_details}",
+        workload.name,
+        run.exit_code,
+    );
+    assert!(
+        run.output.contains(GPU_WORKLOAD_FAILURE_MARKER),
+        "expected failure marker {GPU_WORKLOAD_FAILURE_MARKER} for workload '{}' image {} in failure output:\n{}",
+        workload.name,
+        workload.image,
+        run.output,
+    );
+    run.guard.cleanup().await;
 }
 
 #[tokio::test]

--- a/e2e/rust/tests/provider_auto_create.rs
+++ b/e2e/rust/tests/provider_auto_create.rs
@@ -93,6 +93,7 @@ async fn auto_created_provider_credential_available_in_sandbox() {
         .arg("--provider")
         .arg("claude-code")
         .arg("--auto-providers")
+        .args(["--", "sh", "-c", "exec sleep infinity"])
         .env("ANTHROPIC_API_KEY", TEST_API_KEY)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/e2e/rust/tests/sandbox_lifecycle.rs
+++ b/e2e/rust/tests/sandbox_lifecycle.rs
@@ -7,9 +7,10 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use openshell_e2e::harness::binary::{openshell_cmd, openshell_tty_cmd};
+use openshell_e2e::harness::cli::{run_cli, wait_for_sandbox_phase};
 use openshell_e2e::harness::output::{extract_field, strip_ansi};
 use openshell_e2e::harness::sandbox::SandboxGuard;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::time::{Instant, sleep};
 
 const SANDBOX_PRESENCE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -130,18 +131,100 @@ async fn run_sandbox_lifecycle_command(operation: &str, name: &str) -> String {
     combined
 }
 
+async fn sandbox_details(name: &str) -> String {
+    let (details, exit_code) = run_cli(&["sandbox", "get", name]).await;
+    let details = normalize_output(&details);
+    assert_eq!(
+        exit_code, 0,
+        "sandbox get should succeed for {name}:\n{details}"
+    );
+    details
+}
+
+async fn reconnect_with_input_ownership(
+    sandbox_name: &str,
+) -> (tokio::process::Child, Vec<String>) {
+    let reconnect_deadline = Instant::now() + Duration::from_secs(30);
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+        let token = format!("reconnect-{attempt}");
+        let mut reconnect_cmd = openshell_cmd();
+        reconnect_cmd
+            .args(["sandbox", "connect", sandbox_name])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut candidate = reconnect_cmd.spawn().expect("spawn reconnect attachment");
+        let mut candidate_stdin = candidate.stdin.take().expect("reconnect stdin");
+        candidate_stdin
+            .write_all(format!("{token}\n").as_bytes())
+            .await
+            .expect("write reconnect ownership probe");
+        candidate_stdin
+            .flush()
+            .await
+            .expect("flush reconnect ownership probe");
+
+        let reconnect_stdout = candidate.stdout.take().expect("reconnect stdout");
+        let mut reconnect_lines = BufReader::new(reconnect_stdout).lines();
+        let mut candidate_replay = Vec::new();
+        let remaining = reconnect_deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "reconnect did not acquire input ownership"
+        );
+        let attempt_timeout = Duration::from_secs(2).min(remaining);
+        let acquired = tokio::time::timeout(attempt_timeout, async {
+            loop {
+                let Some(line) = reconnect_lines
+                    .next_line()
+                    .await
+                    .expect("read reconnect output")
+                else {
+                    return false;
+                };
+                if line.contains("main_pid=") {
+                    candidate_replay.push(line.clone());
+                }
+                if line.contains(&format!("input={token}")) {
+                    return true;
+                }
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        if acquired {
+            return (candidate, candidate_replay);
+        }
+
+        let _ = candidate.kill().await;
+        let _ = candidate.wait().await;
+        assert!(
+            Instant::now() < reconnect_deadline,
+            "reconnect did not acquire input ownership"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
 #[tokio::test]
 async fn sandbox_stop_start_preserves_workspace() {
     const SENTINEL: &str = "openshell-stop-start-sentinel";
     const SENTINEL_PATH: &str = "/sandbox/.openshell-stop-start-e2e";
+    const RUN_COUNT_PATH: &str = "/sandbox/.openshell-main-run-count";
     let write_sentinel = format!("printf '%s\\n' '{SENTINEL}' > '{SENTINEL_PATH}'");
+    let main = format!(
+        "count=0; test ! -f '{RUN_COUNT_PATH}' || count=$(cat '{RUN_COUNT_PATH}'); \
+         count=$((count + 1)); printf '%s\\n' \"$count\" > '{RUN_COUNT_PATH}'; \
+         echo lifecycle-ready-$count; exec sleep infinity"
+    );
 
-    let mut sandbox = SandboxGuard::create_keep(
-        &["sh", "-c", "echo lifecycle-ready; exec sleep infinity"],
-        "lifecycle-ready",
-    )
-    .await
-    .expect("sandbox create should start a durable main process");
+    let mut sandbox = SandboxGuard::create_keep(&["sh", "-c", &main], "lifecycle-ready")
+        .await
+        .expect("sandbox create should start a durable main process");
     sandbox
         .exec(&["sh", "-lc", &write_sentinel])
         .await
@@ -189,6 +272,15 @@ async fn sandbox_stop_start_preserves_workspace() {
     assert!(
         sentinel.lines().any(|line| line.trim() == SENTINEL),
         "workspace sentinel should survive stop and start:\n{sentinel}",
+    );
+    let run_count = sandbox
+        .exec(&["cat", RUN_COUNT_PATH])
+        .await
+        .expect("sandbox exec should read the canonical main run count");
+    assert_eq!(
+        run_count.trim(),
+        "2",
+        "start should launch a fresh canonical main instance:\n{run_count}",
     );
 
     sandbox.cleanup().await;
@@ -331,6 +423,42 @@ async fn canonical_main_nonzero_exit_preserves_status() {
 }
 
 #[tokio::test]
+async fn detached_canonical_main_exit_zero_reaches_completed() {
+    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", "exit 0"])
+        .await
+        .expect("create detached successful canonical main");
+
+    wait_for_sandbox_phase(&sandbox.name, "Completed", SANDBOX_PRESENCE_TIMEOUT)
+        .await
+        .unwrap_or_else(|err| panic!("detached successful main did not complete:\n{err}"));
+    let details = sandbox_details(&sandbox.name).await;
+    assert!(
+        details.contains("Phase: Completed"),
+        "detached successful main should retain Completed status:\n{details}"
+    );
+
+    sandbox.cleanup().await;
+}
+
+#[tokio::test]
+async fn detached_canonical_main_nonzero_exit_reaches_error() {
+    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", "exit 11"])
+        .await
+        .expect("create detached failing canonical main");
+
+    wait_for_sandbox_phase(&sandbox.name, "Error", SANDBOX_PRESENCE_TIMEOUT)
+        .await
+        .unwrap_or_else(|err| panic!("detached failing main did not reach Error:\n{err}"));
+    let details = sandbox_details(&sandbox.name).await;
+    assert!(
+        details.contains("Phase: Error") && details.contains("Exit Code: 11"),
+        "detached failing main should retain its terminal result:\n{details}"
+    );
+
+    sandbox.cleanup().await;
+}
+
+#[tokio::test]
 async fn canonical_tty_main_uses_sandbox_environment() {
     let script = r#"printf 'canonical_env home=%s user=%s term=%s\n' "$HOME" "$USER" "$TERM"; while true; do sleep 1; done"#;
     let mut sandbox =
@@ -369,7 +497,7 @@ async fn canonical_tty_main_uses_sandbox_environment() {
 #[tokio::test]
 async fn canonical_main_disconnect_reconnect_replays_history_for_same_process() {
     const FIRST_MARKER: &str = "sequence=0001";
-    let script = r#"n=1; while true; do printf 'main_pid=%s sequence=%04d\n' "$$" "$n"; n=$((n + 1)); sleep 0.2; done"#;
+    let script = r#"trap 'kill "$writer" 2>/dev/null || true' EXIT; (n=1; while true; do printf 'main_pid=%s sequence=%04d\n' "$$" "$n"; n=$((n + 1)); sleep 0.2; done) & writer=$!; while IFS= read -r line; do printf 'main_pid=%s input=%s\n' "$$" "$line"; done"#;
     let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-lc", script])
         .await
         .expect("create retained canonical main process");
@@ -413,46 +541,23 @@ async fn canonical_main_disconnect_reconnect_replays_history_for_same_process() 
     );
     let observer_stdout = observer.stdout.take().expect("observer stdout");
     let mut observer_lines = BufReader::new(observer_stdout).lines();
-    let observed = tokio::time::timeout(Duration::from_secs(30), observer_lines.next_line())
-        .await
-        .expect("observer output timeout")
-        .expect("read observer output")
-        .expect("observer output should remain open");
+    let observer_output_line =
+        tokio::time::timeout(Duration::from_secs(30), observer_lines.next_line())
+            .await
+            .expect("observer output timeout")
+            .expect("read observer output")
+            .expect("observer output should remain open");
     assert!(
-        observed.contains("main_pid="),
-        "read-only attachment should observe output: {observed}"
+        observer_output_line.contains("main_pid="),
+        "read-only attachment should observe output: {observer_output_line}"
     );
 
     owner.kill().await.expect("disconnect input owner");
     owner.wait().await.expect("wait for input owner disconnect");
     observer.kill().await.expect("disconnect observer");
     observer.wait().await.expect("wait for observer disconnect");
-    sleep(Duration::from_millis(600)).await;
 
-    let mut reconnect_cmd = openshell_cmd();
-    reconnect_cmd
-        .args(["sandbox", "connect", &sandbox.name])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut reconnect = reconnect_cmd.spawn().expect("spawn reconnect attachment");
-    let reconnect_stdout = reconnect.stdout.take().expect("reconnect stdout");
-    let mut reconnect_lines = BufReader::new(reconnect_stdout).lines();
-    let mut replay = Vec::new();
-    tokio::time::timeout(Duration::from_secs(30), async {
-        while replay.len() < 5 {
-            let line = reconnect_lines
-                .next_line()
-                .await
-                .expect("read reconnect output")
-                .expect("reconnect output should remain open");
-            if line.contains("main_pid=") {
-                replay.push(line);
-            }
-        }
-    })
-    .await
-    .expect("reconnect history timeout");
+    let (mut reconnect, replay) = reconnect_with_input_ownership(&sandbox.name).await;
 
     let first_pid = owner_line
         .split_whitespace()
@@ -506,6 +611,47 @@ async fn sandbox_create_with_no_keep_cleans_up_after_tty_command() {
         delete_sandbox(&sandbox_name).await;
         panic!(
             "sandbox {sandbox_name} should have been deleted automatically after \
+             {SANDBOX_PRESENCE_TIMEOUT:?}; last observed sandbox list: {last_sandbox_list:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sandbox_create_with_no_keep_preserves_failure_then_cleans_up() {
+    let mut cmd = openshell_tty_cmd(&[
+        "sandbox",
+        "create",
+        "--no-keep",
+        "--",
+        "sh",
+        "-c",
+        "echo ephemeral-failure; exit 17",
+    ]);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let output = cmd.output().await.expect("spawn openshell sandbox create");
+    let combined = normalize_output(&format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    ));
+
+    assert_eq!(
+        output.status.code(),
+        Some(17),
+        "ephemeral main should preserve its failure code:\n{combined}"
+    );
+    assert!(
+        combined.contains("ephemeral-failure"),
+        "ephemeral main output was not streamed:\n{combined}"
+    );
+    let sandbox_name =
+        extract_sandbox_name(&combined).expect("sandbox name should be present in output");
+
+    if let Err(last_sandbox_list) = assert_sandbox_presence_eventually(&sandbox_name, false).await {
+        delete_sandbox(&sandbox_name).await;
+        panic!(
+            "failed ephemeral sandbox {sandbox_name} should have been deleted automatically after \
              {SANDBOX_PRESENCE_TIMEOUT:?}; last observed sandbox list: {last_sandbox_list:?}"
         );
     }

--- a/e2e/rust/tests/sandbox_lifecycle.rs
+++ b/e2e/rust/tests/sandbox_lifecycle.rs
@@ -424,9 +424,15 @@ async fn canonical_main_nonzero_exit_preserves_status() {
 
 #[tokio::test]
 async fn detached_canonical_main_exit_zero_reaches_completed() {
-    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", "exit 0"])
+    const RELEASE_PATH: &str = "/sandbox/.openshell-detached-success-release";
+    let script = format!("while [ ! -e '{RELEASE_PATH}' ]; do sleep 0.05; done; exit 0");
+    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", &script])
         .await
         .expect("create detached successful canonical main");
+    sandbox
+        .exec(&["touch", RELEASE_PATH])
+        .await
+        .expect("release detached successful canonical main");
 
     wait_for_sandbox_phase(&sandbox.name, "Completed", SANDBOX_PRESENCE_TIMEOUT)
         .await
@@ -442,9 +448,15 @@ async fn detached_canonical_main_exit_zero_reaches_completed() {
 
 #[tokio::test]
 async fn detached_canonical_main_nonzero_exit_reaches_error() {
-    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", "exit 11"])
+    const RELEASE_PATH: &str = "/sandbox/.openshell-detached-failure-release";
+    let script = format!("while [ ! -e '{RELEASE_PATH}' ]; do sleep 0.05; done; exit 11");
+    let mut sandbox = SandboxGuard::create_detached_main(&["sh", "-c", &script])
         .await
         .expect("create detached failing canonical main");
+    sandbox
+        .exec(&["touch", RELEASE_PATH])
+        .await
+        .expect("release detached failing canonical main");
 
     wait_for_sandbox_phase(&sandbox.name, "Error", SANDBOX_PRESENCE_TIMEOUT)
         .await

--- a/e2e/rust/tests/sandbox_lifecycle.rs
+++ b/e2e/rust/tests/sandbox_lifecycle.rs
@@ -136,9 +136,16 @@ async fn sandbox_stop_start_preserves_workspace() {
     const SENTINEL_PATH: &str = "/sandbox/.openshell-stop-start-e2e";
     let write_sentinel = format!("printf '%s\\n' '{SENTINEL}' > '{SENTINEL_PATH}'");
 
-    let mut sandbox = SandboxGuard::create(&["--", "sh", "-lc", &write_sentinel])
+    let mut sandbox = SandboxGuard::create_keep(
+        &["sh", "-c", "echo lifecycle-ready; exec sleep infinity"],
+        "lifecycle-ready",
+    )
+    .await
+    .expect("sandbox create should start a durable main process");
+    sandbox
+        .exec(&["sh", "-lc", &write_sentinel])
         .await
-        .expect("sandbox create should write the workspace sentinel");
+        .expect("sandbox exec should write the workspace sentinel");
 
     let stop_output = run_sandbox_lifecycle_command("stop", &sandbox.name).await;
     assert!(
@@ -189,9 +196,12 @@ async fn sandbox_stop_start_preserves_workspace() {
 
 #[tokio::test]
 async fn sandbox_can_be_deleted_while_stopped() {
-    let mut sandbox = SandboxGuard::create(&["--", "true"])
-        .await
-        .expect("sandbox create should succeed");
+    let mut sandbox = SandboxGuard::create_keep(
+        &["sh", "-c", "echo stop-ready; exec sleep infinity"],
+        "stop-ready",
+    )
+    .await
+    .expect("sandbox create should start a durable main process");
 
     let stop_output = run_sandbox_lifecycle_command("stop", &sandbox.name).await;
     assert!(

--- a/e2e/rust/tests/vm_overlay.rs
+++ b/e2e/rust/tests/vm_overlay.rs
@@ -11,9 +11,12 @@ use openshell_e2e::harness::sandbox::SandboxGuard;
 
 #[tokio::test]
 async fn vm_overlay() {
-    let mut sandbox = SandboxGuard::create(&["--", "echo", "vm-sandbox-ready"])
-        .await
-        .expect("sandbox create should succeed");
+    let mut sandbox = SandboxGuard::create_keep(
+        &["sh", "-c", "echo vm-sandbox-ready; exec sleep infinity"],
+        "vm-sandbox-ready",
+    )
+    .await
+    .expect("sandbox create should start a durable main process");
 
     let script = concat!(
         "set -eu; ",


### PR DESCRIPTION
## Summary

Align lifecycle-related E2E tests with the canonical-main, retained terminal-state, and ephemeral cleanup contracts. Use explicit durable mains where tests need a running sandbox, and make tests exercise the intended create semantics instead of silently converting lifecycle flags into scratch-plus-exec behavior.

## Related Issue

No issue required: focused test maintenance correcting E2E lifecycle assumptions.

The production stale-exit race exposed by the stop/start test is addressed separately by #3132.

## Changes

- Start durable canonical mains before stop/start, stopped-delete, VM overlay, and provider auto-create assertions.
- Assert stop/start launches a fresh canonical main instance while preserving workspace data.
- Cover detached successful and failing main processes reaching retained `Completed` and `Error` states.
- Cover nonzero `--no-keep` exit propagation followed by automatic deletion.
- Make reconnect coverage prove stdin ownership transfer instead of relying on a fixed delay.
- Run GPU workloads as canonical create-time mains and verify retained phase and exit status.
- Reject `--no-keep` in the persistent scratch helper and remove misleading callers.
- Keep policy-advisor sandboxes alive, separate upload from execution, and poll for mechanistic output.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test --manifest-path e2e/rust/Cargo.toml --all-features --no-run`
- [x] Affected E2E targets pass strict Clippy
- [x] `mise run e2e:mechanistic-smoke`
- [ ] Focused Docker lifecycle E2E: all new cases pass; the existing stop/start case reproduces the stale `ContainerExited` race fixed by #3132
- [ ] GPU workload E2E not run locally because a GPU is required

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
