### PR TITLE
fix(ci): use multi-arch Fedora image for RPM builds

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 60
     container:
-      image: docker.io/library/fedora:44@sha256:be9d65e2344d805cc11114319c685ecaa96b6d9b4350a0a6460cdb931babbd19
+      image: docker.io/library/fedora:44@sha256:43b29f65a41eb9c35e1cd5323e3bdf3b655c2357a9f4f1ff2f9c2798e5045d80
     steps:
       - name: Install packaging dependencies
         run: |


### PR DESCRIPTION
## Summary

Use Fedora 44's multi-architecture image index so RPM builds run the native image on both AMD64 and ARM64 runners.

## Related Issue

No issue required: this is an obvious localized CI configuration bug.

## Changes

- Replace the AMD64-only Fedora manifest digest with the corresponding multi-architecture index digest

## Testing

- [ ] `mise run pre-commit` passes (not run)
- [ ] Unit tests added/updated (not applicable)
- [ ] E2E tests added/updated (not applicable)
- [x] Verified the pinned index contains matching Linux AMD64 and ARM64 manifests
- [x] `git diff --check` passes

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable — CI-only fix)
