### PR TITLE
fix(ci): wait for snap gateway readiness

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -202,6 +202,17 @@ jobs:
           sudo snap services openshell
           openshell gateway add http://127.0.0.1:17670 --local --name snap-docker
           openshell gateway select snap-docker
+
+          for _ in {1..60}; do
+            if openshell status >/dev/null 2>&1; then
+              openshell status
+              exit 0
+            fi
+            sleep 1
+          done
+
+          sudo snap services openshell
+          sudo snap logs openshell.gateway -n=100 || true
           openshell status
 
   kubernetes:


### PR DESCRIPTION
## Summary

Wait for the Snap-packaged gateway to accept status requests before declaring the Ubuntu Snap canary failed. The service can report active before its listener is ready, which caused an intermittent connection-refused failure.

The same Release Dev commit demonstrated the race: run 33562715502 failed the Ubuntu Snap check while run 33562871938 passed it.

## Related Issue

No issue required: this is an obvious localized release-canary reliability fix.

## Changes

- Poll openshell status for up to 60 seconds after gateway registration.
- Preserve a hard failure when readiness never arrives.
- Print Snap service state and gateway logs on timeout.

## Testing

- [x] mise run pre-commit passes
- [ ] Unit tests added/updated (not applicable: workflow-only change)
- [ ] E2E tests added/updated (not applicable: canary is the E2E smoke test)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable: no architecture change)