### PR TITLE
fix(go-sdk): prevent duplicate credential renewal

### DIFF
--- a/sdk/go/openshell/v1/oidc/credentials_auth.go
+++ b/sdk/go/openshell/v1/oidc/credentials_auth.go
@@ -36,25 +36,12 @@ func NewClientCredentialsAuth(opts ...LoginOption) (types.AuthProvider, error) {
 }
 
 func (a *clientCredentialsAuth) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
-	a.mu.Lock()
-	if a.token != nil && time.Now().Add(clientCredentialsLeeway).Before(a.token.Expiry) {
-		accessToken := a.token.AccessToken
-		a.mu.Unlock()
+	if accessToken, ok := a.cachedAccessToken(); ok {
 		return map[string]string{"authorization": "Bearer " + accessToken}, nil
 	}
-	a.mu.Unlock()
 
 	result := a.group.DoChan("exchange", func() (any, error) {
-		exchangeCtx, cancel := context.WithTimeout(context.Background(), a.cfg.timeout)
-		defer cancel()
-		token, err := exchangeClientCredentials(exchangeCtx, a.cfg, true)
-		if err != nil {
-			return nil, err
-		}
-		a.mu.Lock()
-		a.token = token
-		a.mu.Unlock()
-		return token.AccessToken, nil
+		return a.accessTokenForExchange()
 	})
 	select {
 	case <-ctx.Done():
@@ -65,6 +52,35 @@ func (a *clientCredentialsAuth) GetRequestMetadata(ctx context.Context, _ ...str
 		}
 		return map[string]string{"authorization": "Bearer " + exchange.Val.(string)}, nil
 	}
+}
+
+func (a *clientCredentialsAuth) cachedAccessToken() (string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.token != nil && time.Now().Add(clientCredentialsLeeway).Before(a.token.Expiry) {
+		return a.token.AccessToken, true
+	}
+	return "", false
+}
+
+func (a *clientCredentialsAuth) accessTokenForExchange() (string, error) {
+	// A caller can miss the initial cache check, then become the next flight
+	// leader after another exchange completes and singleflight removes it.
+	// Re-check here so that caller reuses the token instead of exchanging again.
+	if accessToken, ok := a.cachedAccessToken(); ok {
+		return accessToken, nil
+	}
+
+	exchangeCtx, cancel := context.WithTimeout(context.Background(), a.cfg.timeout)
+	defer cancel()
+	token, err := exchangeClientCredentials(exchangeCtx, a.cfg, true)
+	if err != nil {
+		return "", err
+	}
+	a.mu.Lock()
+	a.token = token
+	a.mu.Unlock()
+	return token.AccessToken, nil
 }
 
 func (*clientCredentialsAuth) RequireTransportSecurity() bool { return true }

--- a/sdk/go/openshell/v1/oidc/credentials_test.go
+++ b/sdk/go/openshell/v1/oidc/credentials_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -291,6 +293,19 @@ func TestClientCredentialsAuthSingleFlightRenewalAndFields(t *testing.T) {
 	_, err = auth.GetRequestMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestClientCredentialsAuthLateFlightReusesCachedToken(t *testing.T) {
+	auth := &clientCredentialsAuth{
+		token: &oauth2.Token{
+			AccessToken: "cached-token",
+			Expiry:      time.Now().Add(time.Hour),
+		},
+	}
+
+	accessToken, err := auth.accessTokenForExchange()
+	require.NoError(t, err)
+	assert.Equal(t, "cached-token", accessToken)
 }
 
 func TestClientCredentialsAuthCancellationDoesNotPoisonSharedExchange(t *testing.T) {


### PR DESCRIPTION
## Summary

Prevent late client-credentials callers from starting a redundant token exchange after an earlier singleflight completes. The credential provider now rechecks the token cache after becoming the singleflight leader.

## Related Issue

No issue required: this is an obvious localized Go SDK concurrency bug fix exposed by the existing race-enabled CI test.

## Changes

- Centralize valid cached access-token lookup.
- Recheck the cache at the singleflight leadership boundary before exchanging credentials.
- Add deterministic regression coverage for a caller that arrives after the prior flight completes.

## Testing

- [x] `mise run pre-commit`
- [x] `mise run go:ci`
- [x] `mise run test`
- [x] `mise run ci`
- [x] Focused race tests repeated 500 times
- [ ] E2E tests (not applicable to SDK credential concurrency)

## Checklist

- [x] Commit uses Conventional Commits.
- [x] Commit includes DCO sign-off.
- [x] Documentation and architecture updates are not required for this internal concurrency fix.
