### PR TITLE
ci: add branch check and test timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,8 @@
 
 [profile.ci]
 fail-fast = false
-status-level = "fail"
+status-level = "slow"
 final-status-level = "fail"
 failure-output = "immediate-final"
+# Print slow test names after 30 seconds and terminate them after two minutes.
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -41,6 +41,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -65,6 +66,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -84,6 +86,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     defaults:
       run:
         shell: nix develop .#devShells.x86_64-linux.default -c bash -euo pipefail {0}
@@ -117,6 +120,7 @@ jobs:
           - runner: macos-15-xlarge
             system: aarch64-darwin
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     defaults:
       run:
         shell: nix develop .#devShells.${{ matrix.system }}.default -c bash -euo pipefail {0}
@@ -200,6 +204,7 @@ jobs:
       matrix:
         runner: [linux-amd64-cpu8, linux-arm64-cpu8]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -231,6 +236,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -250,6 +256,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:
@@ -269,6 +276,7 @@ jobs:
     needs: pr_metadata
     if: needs.pr_metadata.outputs.should_run == 'true'
     runs-on: linux-amd64-cpu8
+    timeout-minutes: 30
     container:
       image: ghcr.io/nvidia/openshell/ci:latest
       credentials:


### PR DESCRIPTION
## Summary

Prevent branch checks from running indefinitely and make hung Rust tests identify themselves in the CI log. This follows [Branch Checks run 33643869577](https://github.com/NVIDIA/OpenShell/actions/runs/33643869577), where all three Rust test jobs remained active for more than two hours.

The 30-minute job cap is more than twice the slowest sampled successful job, including cold-cache runs, which completed within 14 minutes 17 seconds.

## Related Issue

No issue required: this is a localized CI reliability and diagnostics change.

## Changes

- Add a 30-minute timeout to all eight substantive branch-check jobs
- Report nextest tests as slow after 30 seconds
- Terminate individual tests after two minutes and report them as timed out

## Testing

- [x] `mise run pre-commit` passes
- [x] Branch Checks workflow parses as YAML and all substantive jobs have the expected timeout
- [x] Nextest configuration parses as TOML with the expected slow-test settings
- [x] `git diff --check` passes
- [ ] `actionlint` was unavailable locally; GitHub Actions will validate the workflow

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off for DCO
- [x] Architecture documentation is not applicable to this CI-only change
