### PR TITLE
fix(driver-mxc): implement authenticate_sandbox trait method

### DIFF
--- a/crates/openshell-driver-mxc/src/grpc.rs
+++ b/crates/openshell-driver-mxc/src/grpc.rs
@@ -9,14 +9,15 @@
 use crate::driver::MxcComputeBackend;
 use futures::{Stream, StreamExt};
 use openshell_core::proto::compute::v1::{
-    CreateSandboxRequest, CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse,
-    DeleteWorkspaceRequest, DeleteWorkspaceResponse, EnsureWorkspaceRequest,
-    EnsureWorkspaceResponse, GetCapabilitiesRequest, GetCapabilitiesResponse,
-    GetGatewayListenerRequirementsRequest, GetGatewayListenerRequirementsResponse,
-    GetSandboxRequest, GetSandboxResponse, ListSandboxesRequest, ListSandboxesResponse,
-    StartSandboxRequest, StartSandboxResponse, StopSandboxRequest, StopSandboxResponse,
-    ValidateSandboxCreateRequest, ValidateSandboxCreateResponse, WatchSandboxesEvent,
-    WatchSandboxesRequest, compute_driver_server::ComputeDriver,
+    AuthenticateSandboxRequest, AuthenticateSandboxResponse, CreateSandboxRequest,
+    CreateSandboxResponse, DeleteSandboxRequest, DeleteSandboxResponse, DeleteWorkspaceRequest,
+    DeleteWorkspaceResponse, EnsureWorkspaceRequest, EnsureWorkspaceResponse,
+    GetCapabilitiesRequest, GetCapabilitiesResponse, GetGatewayListenerRequirementsRequest,
+    GetGatewayListenerRequirementsResponse, GetSandboxRequest, GetSandboxResponse,
+    ListSandboxesRequest, ListSandboxesResponse, StartSandboxRequest, StartSandboxResponse,
+    StopSandboxRequest, StopSandboxResponse, ValidateSandboxCreateRequest,
+    ValidateSandboxCreateResponse, WatchSandboxesEvent, WatchSandboxesRequest,
+    compute_driver_server::ComputeDriver,
 };
 use std::pin::Pin;
 use tonic::{Request, Response, Status};
@@ -39,6 +40,15 @@ impl ComputeDriver for ComputeDriverService {
         _request: Request<GetCapabilitiesRequest>,
     ) -> Result<Response<GetCapabilitiesResponse>, Status> {
         Ok(Response::new(self.backend.capabilities()))
+    }
+
+    async fn authenticate_sandbox(
+        &self,
+        _request: Request<AuthenticateSandboxRequest>,
+    ) -> Result<Response<AuthenticateSandboxResponse>, Status> {
+        Err(Status::unimplemented(
+            "mxc does not authenticate sandbox credentials",
+        ))
     }
 
     async fn get_gateway_listener_requirements(


### PR DESCRIPTION
> **🏗️ build-from-issue-agent**

## Summary
Add the missing `authenticate_sandbox` method to the MXC driver's `ComputeDriver` impl, fixing the compilation error introduced by commit 9b6d904e. The method returns `Status::unimplemented`, matching the Docker and Podman drivers, since the MXC driver advertises `supports_sandbox_authentication: false`.

## Related Issue
Closes #3155

## Changes
- `crates/openshell-driver-mxc/src/grpc.rs`: Added `AuthenticateSandboxRequest`/`AuthenticateSandboxResponse` imports and implemented `authenticate_sandbox` returning `Status::unimplemented("mxc does not authenticate sandbox credentials")`

### Deviations from Plan
None — implemented as planned. The `supports_sandbox_authentication` field in `driver.rs` was already present (set to `false`), so only the trait method in `grpc.rs` needed adding.

## Testing
- [x] `mise run pre-commit` passes (proto:lint failure is pre-existing Windows env issue)
- [x] `cargo check -p openshell-driver-mxc` compiles cleanly
- [x] `cargo test -p openshell-driver-mxc` — all 75 tests pass (27 unit + 48 integration, 9 ignored as expected)

**Tests added:**
- **Unit:** N/A — one-line unimplemented stub behind a capability gate; matches Docker/Podman pattern which also don't test their stubs
- **Integration:** N/A
- **E2E:** N/A

## Checklist
- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)

**Documentation updated:**
- None needed — mechanical trait conformance fix with no user-facing behavior change