### PR TITLE
docs: add project maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Maintainers
+
+The current maintainers of OpenShell are listed below.
+
+| Name | GitHub ID | Company/Organization |
+| --- | --- | --- |
+| Derek Carr | [@derekwaynecarr](https://github.com/derekwaynecarr) | Red Hat |
+| Matthew Grossman | [@matthewgrossman](https://github.com/matthewgrossman) | NVIDIA |
+| Kris Hicks | [@krishicks](https://github.com/krishicks) | NVIDIA |
+| Seth Jennings | [@sjenning](https://github.com/sjenning) | Red Hat |
+| Adrien Langou | [@alangou](https://github.com/alangou) | NVIDIA |
+| Evan Lezar | [@elezar](https://github.com/elezar) | NVIDIA |
+| Jim Meyer | [@purp](https://github.com/purp) | NVIDIA |
+| Piotr Mlocek | [@pimlock](https://github.com/pimlock) | NVIDIA |
+| Taylor Mutch | [@TaylorMutch](https://github.com/TaylorMutch) | NVIDIA |
+| John T. Myers | [@johntmyers](https://github.com/johntmyers) | NVIDIA |
+| Drew Newberry | [@drew](https://github.com/drew) | NVIDIA |
+| Mrunal Patel | [@mrunalp](https://github.com/mrunalp) | Red Hat |
+| Simon Scatton | [@SDAChess](https://github.com/SDAChess) | NVIDIA |


### PR DESCRIPTION
## Summary

Add a maintainer roster for OpenShell based on the CNCF project template. The roster identifies the NVIDIA and Red Hat maintainers who can review and merge pull requests.

## Related Issue

No issue required: this is a small repository governance documentation addition.

## Changes

- Add `MAINTAINERS.md` with maintainer names, GitHub IDs, and affiliations
- List maintainers alphabetically by last name

## Testing

- [x] `git diff --cached --check` passes
- [ ] `mise run pre-commit` passes (skipped at requester direction)
- [ ] Unit tests added/updated (not applicable; documentation only)
- [ ] E2E tests added/updated (not applicable; documentation only)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no architecture change)
