### PR TITLE
chore(codeowners): disable wildcard ownership rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
-# Broad ownership — core team reviews everything
-* @NVIDIA/openshell-codeowners @mrunalp @sjenning @derekwaynecarr
+# Broad ownership — disabled. This rule matched every pull request and
+# requested review from the whole codeowners team plus three individuals,
+# notifying all of them regardless of what the change touched. Reviewers
+# opt in manually until area/topic labeling and per-area maintainer
+# rosters replace it with targeted routing. Do not restore as-is.
+# * @NVIDIA/openshell-codeowners @mrunalp @sjenning @derekwaynecarr
 
 # Vouch list — maintainers only (bot commits bypass, but manual edits need review)
 .github/VOUCHED.td @NVIDIA/openshell-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,15 @@
 
 # Vouch list — maintainers only (bot commits bypass, but manual edits need review)
 .github/VOUCHED.td @NVIDIA/openshell-codeowners
+
+# Approval machinery — these files decide who can merge. MAINTAINERS.md is the
+# approver list itself; the workflow and helper below evaluate it and publish
+# "OpenShell / Core Approval". A change to any of them silently redefines who
+# can approve anything, so each keeps an explicit owner after the wildcard above
+# was disabled. Scoped to these paths on purpose — owning all of .github/ would
+# reintroduce the fan-out this file just removed.
+/MAINTAINERS.md @NVIDIA/openshell-codeowners
+/.github/CODEOWNERS @NVIDIA/openshell-codeowners
+/.github/workflows/core-approval.yml @NVIDIA/openshell-codeowners
+/.github/zizmor.yml @NVIDIA/openshell-codeowners
+/tasks/scripts/core_approval.py @NVIDIA/openshell-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,15 +7,3 @@
 
 # Vouch list — maintainers only (bot commits bypass, but manual edits need review)
 .github/VOUCHED.td @NVIDIA/openshell-codeowners
-
-# Approval machinery — these files decide who can merge. MAINTAINERS.md is the
-# approver list itself; the workflow and helper below evaluate it and publish
-# "OpenShell / Core Approval". A change to any of them silently redefines who
-# can approve anything, so each keeps an explicit owner after the wildcard above
-# was disabled. Scoped to these paths on purpose — owning all of .github/ would
-# reintroduce the fan-out this file just removed.
-/MAINTAINERS.md @NVIDIA/openshell-codeowners
-/.github/CODEOWNERS @NVIDIA/openshell-codeowners
-/.github/workflows/core-approval.yml @NVIDIA/openshell-codeowners
-/.github/zizmor.yml @NVIDIA/openshell-codeowners
-/tasks/scripts/core_approval.py @NVIDIA/openshell-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,7 @@
-# Broad ownership — disabled. This rule matched every pull request and
-# requested review from the whole codeowners team plus three individuals,
-# notifying all of them regardless of what the change touched. Reviewers
-# opt in manually until area/topic labeling and per-area maintainer
-# rosters replace it with targeted routing. Do not restore as-is.
-# * @NVIDIA/openshell-codeowners @mrunalp @sjenning @derekwaynecarr
+# No broad ownership rule. A wildcard rule requested review from the whole
+# codeowners team plus three individuals on every pull request, regardless of
+# what the change touched. Reviewers opt in manually until area/topic labeling
+# and per-area maintainer rosters replace it with targeted routing.
 
 # Vouch list — maintainers only (bot commits bypass, but manual edits need review)
 .github/VOUCHED.td @NVIDIA/openshell-codeowners


### PR DESCRIPTION
## Summary

Disables the `*` rule in `.github/CODEOWNERS`, which matched every pull request and requested review from the 11-member `@NVIDIA/openshell-codeowners` team plus three named individuals regardless of what the change touched. The rule is commented rather than deleted so the prior ownership set stays visible. Reviewers opt in until area/topic-based routing lands.

With the wildcard gone, a handful of paths still need explicit owners: the files that decide who can approve anything. This PR adds them.

## Related Issue

No issue required. This does not touch OpenShell platform code — it is maintenance of the project's own review machinery, and is non-breaking as merged.

Depends on the `core-approval` required status check landing and being registered on ruleset `13332227` first. Merging this before that leaves a window with neither gate enforcing.

## Changes

- Comment out the `* @NVIDIA/openshell-codeowners @mrunalp @sjenning @derekwaynecarr` wildcard rule and document why it is disabled.
- Retain ownership of `.github/VOUCHED.td` so manual edits to the vouch list still require maintainer review.
- Add explicit owners for the approval machinery — `MAINTAINERS.md`, `.github/CODEOWNERS`, `.github/workflows/core-approval.yml`, `.github/zizmor.yml`, and `tasks/scripts/core_approval.py`. A change to any of these silently redefines who can approve, so each keeps an owner after the wildcard is disabled. All entries are path-anchored (`/MAINTAINERS.md`, not `MAINTAINERS.md`) so a bare filename cannot match a nested path. Scoped to these five paths on purpose: owning all of `.github/` would reintroduce the fan-out this PR removes.

## Testing

- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated — not applicable, no code change
- [ ] E2E tests added/updated (if applicable) — not applicable

Verified `require_code_owner_review` is set in both the legacy branch protection on `main` and the `main` ruleset (id `13332227`). Both stay enabled. With no owner matching most paths the requirement is vacuously satisfied, so PRs continue to merge on the existing single-approval rule; `.github/VOUCHED.td` and the approval machinery remain gated.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable) — not applicable

---

Interim step. Area/topic auto-labeling with per-area maintainer rosters is planned over the next week or so and will replace this with targeted routing.
