### PR TITLE
fix(cli): validate logs --level and --source values

### DIFF
--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -785,6 +785,12 @@ enum LogLevel {
     Error,
     Warn,
     Info,
+    /// Accepted because the gateway ranks OCSF alongside INFO, so this has
+    /// always worked as a threshold. Hidden rather than advertised: it selects
+    /// exactly the same lines as `info`, and offering two spellings for one
+    /// threshold in `--help` would suggest a distinction that does not exist.
+    #[value(hide = true)]
+    Ocsf,
     Debug,
     Trace,
 }
@@ -795,6 +801,7 @@ impl LogLevel {
             Self::Error => "error",
             Self::Warn => "warn",
             Self::Info => "info",
+            Self::Ocsf => "ocsf",
             Self::Debug => "debug",
             Self::Trace => "trace",
         }
@@ -4541,9 +4548,19 @@ mod tests {
 
     #[test]
     fn logs_level_accepts_known_values_any_case() {
-        for value in ["error", "warn", "info", "debug", "trace", "ERROR", "Warn"] {
+        for value in [
+            "error", "warn", "info", "debug", "trace", "ERROR", "Warn", "ocsf", "OCSF",
+        ] {
             Cli::try_parse_from(["openshell", "logs", "sb", "--level", value])
                 .unwrap_or_else(|err| panic!("--level {value} should parse: {err}"));
+        }
+    }
+
+    #[test]
+    fn logs_source_accepts_known_values_any_case() {
+        for value in ["gateway", "sandbox", "all", "Gateway", "SANDBOX"] {
+            Cli::try_parse_from(["openshell", "logs", "sb", "--source", value])
+                .unwrap_or_else(|err| panic!("--source {value} should parse: {err}"));
         }
     }
 

--- a/crates/openshell-cli/src/main.rs
+++ b/crates/openshell-cli/src/main.rs
@@ -539,12 +539,12 @@ enum Commands {
 
         /// Filter by log source: "gateway", "sandbox", or "all" (default).
         /// Can be specified multiple times: --source gateway --source sandbox
-        #[arg(long, default_value = "all")]
-        source: Vec<String>,
+        #[arg(long, value_enum, ignore_case = true, default_value = "all")]
+        source: Vec<LogSource>,
 
-        /// Minimum log level to display: error, warn, info (default), debug, trace.
-        #[arg(long, default_value = "")]
-        level: String,
+        /// Minimum log level to display: error, warn, info, debug, trace.
+        #[arg(long, value_enum, ignore_case = true)]
+        level: Option<LogLevel>,
     },
 
     /// Manage sandbox policy.
@@ -751,6 +751,54 @@ fn normalize_completion_script(output: Vec<u8>, executable: &std::path::Path) ->
     let script = String::from_utf8(output)
         .map_err(|e| miette::miette!("generated completions were not valid UTF-8: {e}"))?;
     Ok(script.replace(executable.to_string_lossy().as_ref(), "openshell"))
+}
+
+/// Log source accepted by `openshell logs --source`.
+///
+/// The server matches sources by exact string, so an unrecognized value
+/// silently filters every line out. Restricting the flag to known values makes
+/// a typo an argument error instead of an empty result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum LogSource {
+    Gateway,
+    Sandbox,
+    All,
+}
+
+impl LogSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Gateway => "gateway",
+            Self::Sandbox => "sandbox",
+            Self::All => "all",
+        }
+    }
+}
+
+/// Minimum severity accepted by `openshell logs --level`.
+///
+/// The server ranks an unrecognized level below every real one, so a typo
+/// silently disables the filter and returns all levels. Restricting the flag to
+/// known values makes that a visible argument error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -2794,14 +2842,19 @@ async fn run_async() -> Result<()> {
             let mut tls = tls.with_gateway_name(&ctx.name);
             apply_auth(&mut tls, &ctx.name);
             let name = resolve_sandbox_name(name, &ctx.name, &cli.workspace)?;
+            let sources = source
+                .iter()
+                .map(|value| value.as_str().to_string())
+                .collect::<Vec<_>>();
+            let level = level.map_or("", LogLevel::as_str);
             run::sandbox_logs(
                 &ctx.endpoint,
                 &name,
                 n,
                 tail,
                 since.as_deref(),
-                &source,
-                &level,
+                &sources,
+                level,
                 &cli.workspace,
                 &tls,
             )
@@ -4484,6 +4537,60 @@ mod tests {
 
         assert_eq!(from.get_value_hint(), ValueHint::AnyPath);
         assert_eq!(dest.get_value_hint(), ValueHint::AnyPath);
+    }
+
+    #[test]
+    fn logs_level_accepts_known_values_any_case() {
+        for value in ["error", "warn", "info", "debug", "trace", "ERROR", "Warn"] {
+            Cli::try_parse_from(["openshell", "logs", "sb", "--level", value])
+                .unwrap_or_else(|err| panic!("--level {value} should parse: {err}"));
+        }
+    }
+
+    /// The server ranks an unrecognized level below every real one, so a typo
+    /// used to disable the filter and return all levels instead of erroring.
+    #[test]
+    fn logs_level_rejects_unknown_values() {
+        for value in ["warning", "critical", "wanr", ""] {
+            Cli::try_parse_from(["openshell", "logs", "sb", "--level", value])
+                .expect_err(&format!("--level {value} should be rejected"));
+        }
+    }
+
+    /// The server matches sources by exact string, so a typo used to filter
+    /// every line out and return nothing instead of erroring.
+    #[test]
+    fn logs_source_rejects_unknown_values() {
+        Cli::try_parse_from(["openshell", "logs", "sb", "--source", "gatewy"])
+            .expect_err("--source gatewy should be rejected");
+    }
+
+    #[test]
+    fn logs_source_accepts_repeated_known_values() {
+        let cli = Cli::try_parse_from([
+            "openshell",
+            "logs",
+            "sb",
+            "--source",
+            "gateway",
+            "--source",
+            "sandbox",
+        ])
+        .expect("repeated --source should parse");
+        let Some(Commands::Logs { source, .. }) = cli.command else {
+            panic!("expected logs command");
+        };
+        assert_eq!(source, vec![LogSource::Gateway, LogSource::Sandbox]);
+    }
+
+    #[test]
+    fn logs_defaults_to_all_sources_and_no_level_filter() {
+        let cli = Cli::try_parse_from(["openshell", "logs", "sb"]).expect("logs should parse");
+        let Some(Commands::Logs { source, level, .. }) = cli.command else {
+            panic!("expected logs command");
+        };
+        assert_eq!(source, vec![LogSource::All]);
+        assert_eq!(level, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`openshell logs` accepts any string for `--level` and `--source` and forwards it to the gateway, where an unrecognized value is silently ignored rather than rejected. A typo produces wrong output with no indication anything went wrong, and the two flags fail in opposite directions.

## Related Issue

No issue required: obvious localized bug fix in CLI argument handling.

## Changes

- `--level` is now a value enum (`error`, `warn`, `info`, `debug`, `trace`), case-insensitive, defaulting to no filter.
- `--source` is now a value enum (`gateway`, `sandbox`, `all`), case-insensitive, still repeatable and still defaulting to `all`.
- Added tests for accepted values in mixed case, rejected typos on both flags, repeated `--source`, and unchanged defaults.

## The bug

`--level warning` instead of `warn` returns every level, and a mistyped `--source` returns nothing:

```
--level warn     -> shows ERROR,WARN
--level warning  -> shows ERROR,WARN,INFO,DEBUG,TRACE
--source gateway -> shows ["gateway"]
--source gatewy  -> shows []
```

That output is from running the gateway's own `level_matches` and `source_matches` (`crates/openshell-server/src/grpc/validation.rs`) against each level and source.

`level_matches` ranks an unrecognized level at 5, below every real level, so using one as the threshold lets everything through. `source_matches` compares by exact string, so a mistyped source matches nothing.

## Why this belongs in the CLI

The server's `// unknown levels always pass` looks deliberate, and for a log line's own level it is: a sandbox emitting an unusual level should not silently disappear. The same `to_num` is also applied to the caller's threshold, where the same permissiveness just disables the filter.

Validating in the CLI keeps the server's behavior for log lines intact and rejects the case the user can actually get wrong, at the point where the error can name the valid values. It also gives the flags shell completion.

The gateway still accepts unrecognized levels from other clients. Tightening that is a wider change across the SDKs and seemed worth separating from this.

## Testing

- [ ] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

No mise or Docker locally, so I ran the steps individually:

- `cargo fmt --all -- --check` clean
- `cargo test -p openshell-cli` passes, 0 failures, including the five new tests
- `cargo clippy -p openshell-cli --all-targets -- -D warnings` clean

`openshell logs --level warn`, `--level ERROR`, and repeated `--source` all still parse as before, and the defaults are unchanged.

## Two behavior changes worth calling out

`--level ocsf` used to be accepted. The gateway groups `INFO | OCSF` at the same rank, so it behaved as `info`. It is not in the docs or the flag help, so it is not in the enum, but it did work and would now be rejected. Happy to add it if you would rather keep it.

A script passing an invalid level today gets all levels back and exits 0. After this it gets an argument error. That is the point of the change, but it is a visible difference for anyone who has been relying on the broken filter without noticing.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)

---

Assisted by Opus 5.0.
