### PR TITLE
test(conformance): test candidate RPMs directly

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -154,7 +154,7 @@ jobs:
           name: openshell-conformance-x86_64-unknown-linux-musl
           path: conformance-input
 
-      - name: Run RPM gateway continuity conformance
+      - name: Run candidate RPM gateway conformance
         shell: bash
         run: |
           set -euo pipefail
@@ -173,11 +173,11 @@ jobs:
             --distro fedora \
             --with podman-rootless \
             --with selinux \
-            --copy "${candidate_cli_package[0]}:/var/lib/openshell-conformance/candidate/openshell.rpm" \
-            --copy "${candidate_gateway_package[0]}:/var/lib/openshell-conformance/candidate/openshell-gateway.rpm" \
+            --install "${candidate_cli_package[0]}" \
+            --install "${candidate_gateway_package[0]}" \
             --copy conformance-input/openshell-conformance:/tmp/openshell-conformance \
-            --copy nix/test-guest/conformance-plans/gateway-upgrade-restart.toml:/tmp/conformance-plan.toml \
-            --provision openshell-rpm-latest-release \
+            --copy nix/test-guest/conformance-plans/gateway-restart.toml:/tmp/conformance-plan.toml \
+            --provision openshell-rpm \
             --provision gateway-rootless-podman \
-            --provision openshell-rpm-gateway-upgrade \
-            -- /tmp/openshell-conformance run --plan /tmp/conformance-plan.toml
+            -- /home/openshell/.local/bin/openshell-test-guest-as-gateway-user \
+              /tmp/openshell-conformance run --plan /tmp/conformance-plan.toml

--- a/crates/openshell-conformance/src/plan.rs
+++ b/crates/openshell-conformance/src/plan.rs
@@ -150,6 +150,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_gateway_restart_plan() {
+        let plan = ConformancePlan::parse(include_str!(
+            "../../../nix/test-guest/conformance-plans/gateway-restart.toml"
+        ))
+        .expect("gateway restart plan must remain valid");
+
+        assert_eq!(plan.runs.len(), 2);
+        assert_eq!(plan.runs[1].scenario, "sandbox-continuity");
+        assert_eq!(plan.runs[1].actions[0].name, "gateway-restart");
+    }
+
+    #[test]
     fn parses_plan_diagnostics() {
         let plan = ConformancePlan::parse(
             r#"

--- a/nix/test-guest/README.md
+++ b/nix/test-guest/README.md
@@ -217,8 +217,10 @@ EOF
 `openshell-rpm` expects OpenShell to have been installed with `--install`. It
 uses the RPM-owned `/usr/bin` binaries and `openshell-gateway` user service,
 without copied development artifacts or a supervisor archive. Compose it with
-`gateway-rootless-podman` before an RPM action such as
-`openshell-rpm-gateway-upgrade`.
+`gateway-rootless-podman` to test the installed candidate directly. The
+`gateway-restart.toml` plan covers the candidate through smoke and
+gateway-restart continuity checks. `gateway-upgrade-restart.toml` retains the
+separate upgrade action contract for dedicated upgrade testing.
 
 `openshell-rpm-latest-release` downloads and installs the latest stable
 OpenShell GitHub release for the guest architecture, then publishes the same

--- a/nix/test-guest/conformance-plans/gateway-restart.toml
+++ b/nix/test-guest/conformance-plans/gateway-restart.toml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+
+[diagnostics]
+command = "/home/openshell/.local/bin/openshell-test-guest-diagnostics"
+timeout_secs = 60
+
+[[runs]]
+scenario = "smoke"
+
+[[runs]]
+scenario = "sandbox-continuity"
+workload_expectation = "reconciled"
+
+[[runs.actions]]
+name = "gateway-restart"
+command = "/home/openshell/.local/bin/openshell-test-guest-gateway-restart"
+timeout_secs = 120


### PR DESCRIPTION
## Summary

Run Fedora conformance against the CLI and gateway RPMs built by the same workflow, rather than upgrading from a released baseline.

## Related Issue

No issue required: isolated CI conformance coverage split from PR #3165.

## Changes

- Install the built candidate CLI and gateway RPMs directly in the Fedora guest.
- Provision the installed RPM gateway and run a restart-only conformance plan as the gateway user.
- Add parser coverage for the new restart plan, limited to base-branch scenarios.

## Testing

- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated (`cargo test -p openshell-conformance plan::tests`)
- [ ] E2E tests added/updated (if applicable; exercised in CI)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)