### PR TITLE
fix(docker): reclaim sandbox token files on out-of-band removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,6 +7113,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
+ "futures",
  "parking_lot",
 ]
 

--- a/crates/openshell-driver-docker/Cargo.toml
+++ b/crates/openshell-driver-docker/Cargo.toml
@@ -45,7 +45,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 prost-types = { workspace = true }
 tar = "0.4"
-temp-env = "0.3"
+temp-env = { version = "0.3", features = ["async_closure"] }
 tempfile = "3"
 tracing-subscriber = { workspace = true }
 

--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -1104,6 +1104,11 @@ impl DockerComputeDriver {
                     }
                 }
             }
+            // Container gone and no in-memory record survived (gateway
+            // restarted after an out-of-band `docker rm`). DeleteSandbox is
+            // the only thing that ever reclaims the token file, so reclaim it
+            // here too.
+            cleanup_sandbox_token_file_for_delete(sandbox_id, None, &self.config);
             return Ok(false);
         };
         let Some(target) = summary_container_target(&container) else {

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -209,6 +209,29 @@ fn request_with_traceparent<T>(message: T) -> Request<T> {
     request
 }
 
+async fn fake_docker_with_no_containers() -> (String, JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            openshell_core::net::set_tcp_nodelay_best_effort(&stream);
+            let mut scratch = [0_u8; 4096_usize];
+            let _ = stream.read(&mut scratch).await;
+            let _ = stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                           Content-Type: application/json\r\n\
+                           Content-Length: 2\r\n\r\n[]",
+                )
+                .await;
+            let _ = stream.flush().await;
+        }
+    });
+    (format!("http://{address}"), server)
+}
+
 async fn standalone_traced_client() -> (
     TestDriverClient,
     tokio::sync::oneshot::Sender<()>,
@@ -3717,4 +3740,78 @@ fn managed_container_identity_requires_the_configured_namespace() {
         "sbx-alpha",
         "demo"
     ));
+}
+
+#[tokio::test]
+async fn delete_sandbox_reclaims_token_file_when_container_and_pending_are_gone() {
+    let state_dir = tempfile::tempdir().unwrap();
+    let (endpoint, server) = fake_docker_with_no_containers().await;
+
+    temp_env::async_with_vars([("XDG_STATE_HOME", Some(state_dir.path()))], async {
+        let config = runtime_config();
+        let mut driver = test_driver_with_config(config.clone());
+        driver.docker = Arc::new(
+            Docker::connect_with_http(&endpoint, 5, bollard::API_DEFAULT_VERSION).unwrap(),
+        );
+
+        // Arrange the leak: token on disk, container gone, `pending` empty.
+        let token = openshell_core::driver_utils::sandbox_token_path(
+            "docker-sandbox-tokens",
+            Some(&config.sandbox_namespace),
+            "sandbox-1",
+        )
+        .unwrap();
+
+        fs::create_dir_all(token.parent().unwrap()).unwrap();
+        fs::write(&token, "jwt\n").unwrap();
+
+        let deleted = driver.delete_sandbox_inner("sandbox-1", "").await.unwrap();
+        assert!(!deleted, "nothing was removed, must not claim a deletion");
+        assert!(!token.exists(), "token file must be reclaimed");
+    })
+    .await;
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn delete_sandbox_by_name_only_leaves_the_namespace_directory_alone() {
+    // `DeleteSandbox` accepts a name without an id. With no id there is no
+    // token path to derive, so the cleanup must be a no-op: deriving a path
+    // from an empty id yields `<namespace>/sandbox.jwt`, whose parent is the
+    // shared namespace directory.
+    let state_dir = tempfile::tempdir().unwrap();
+    let (endpoint, server) = fake_docker_with_no_containers().await;
+
+    temp_env::async_with_vars([("XDG_STATE_HOME", Some(state_dir.path()))], async {
+        let config = runtime_config();
+        let mut driver = test_driver_with_config(config.clone());
+        driver.docker = Arc::new(
+            Docker::connect_with_http(&endpoint, 5, bollard::API_DEFAULT_VERSION).unwrap(),
+        );
+
+        let namespace_dir = openshell_core::driver_utils::sandbox_token_path(
+            "docker-sandbox-tokens",
+            Some(&config.sandbox_namespace),
+            "sandbox-1",
+        )
+        .unwrap()
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .to_path_buf();
+        fs::create_dir_all(&namespace_dir).unwrap();
+
+        let deleted = driver.delete_sandbox_inner("", "sandbox-1").await.unwrap();
+
+        assert!(!deleted, "nothing was removed, must not claim a deletion");
+        assert!(
+            namespace_dir.is_dir(),
+            "namespace directory must survive a name-only delete: {}",
+            namespace_dir.display()
+        );
+    })
+    .await;
+
+    server.abort();
 }


### PR DESCRIPTION
## Summary

`delete_sandbox_inner` skipped per-sandbox token file cleanup on one exit path — Docker reports no container **and** no in-memory pending record survives — leaving the sandbox's gateway JWT on disk indefinitely. Every other exit path in that function already cleans up. This adds the missing call plus regression coverage.

## Related Issue

Fixes #3041

## Changes

- `crates/openshell-driver-docker/src/lib.rs`: call `cleanup_sandbox_token_file_for_delete` in the "container gone, no pending record" branch of `delete_sandbox_inner`.
  - Uses `_for_delete` rather than `_by_id` because delete accepts a name with no id (`require_sandbox_identifier` requires only one of the two). With an empty id, `sandbox_token_path` resolves to `<namespace>/sandbox.jwt`, whose parent is the shared namespace directory. `_for_delete` guards on `!sandbox_id.is_empty()`.
  - Keeps the `Ok(false)` return: nothing was removed from Docker, so no deletion is claimed and no `Deleted` watch event fires.
- `crates/openshell-driver-docker/src/tests.rs`: two regression tests, plus a loopback stub that answers Docker's `GET /containers/json` with `[]` so the branch is reachable without a daemon.
- `crates/openshell-driver-docker/Cargo.toml` / `Cargo.lock`: enable `temp-env`'s `async_closure` feature. The sync `with_vars` cannot wrap an async test body, and the tests need `XDG_STATE_HOME` scoped to a tempdir.

Left alone deliberately: the adjacent `summary_container_target` → `None` branch returns `Ok(pending.is_some())` without removing the container. That one is a live container being silently abandoned, not a token leak — adding cleanup there would revoke a running sandbox's credential. Worth its own issue; `stop_sandbox_inner` handles the identical case with `Err(Status::not_found)`.

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)