### PR TITLE
refactor(policy)!: remove NetworkBinary harness field

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -343,7 +343,12 @@ Compute-driver, credential-driver, gateway-interceptor, and
 supervisor-middleware services are compiled contracts for internal extension
 boundaries, not public gateway RPCs. The current public inventory has 74
 methods, 278 messages, and 12 enums
-(`0f14943574349d02bdc61076c8c5a59a98b627325564ef1a6d21d7941825dc46`).
+(`8ac68c71d93e6a5e56406b8df1882ee40c6066270969e03eb99803f0e6396fc1`).
+The removed `NetworkBinary.harness` field remains reserved by number and name,
+so protobuf implementations cannot reuse its wire slot or source identifier.
+The durable-policy compatibility decoder reads the former boolean before Prost
+discards it and migrates advisor provenance to the rule endpoint. A fixed
+pre-0.1.0 policy payload verifies that the former wire format still decodes.
 
 Storage-only messages live in the private, versioned
 `openshell.storage.v1` package under `crates/openshell-server/proto`. The server
@@ -359,7 +364,7 @@ Go, Python, and TypeScript client generation inputs do not advertise them.
 | Embedded encoded root | `SandboxPolicy` | Stored in policy rows and inside the JSON settings envelope. |
 
 The 12 encoded durable roots above have a closure of 81 messages and eight
-enums (`920a5243dfb37ce709f0f562a47d17791a5ede90fd7f662ed01542abd60a0dfb`).
+enums (`369b36511c2e38b9df9621704a00123516c7538d8ee89a499158d7de5cee1882`).
 Its intersection with the public RPC closure contains 71 messages and eight
 enums (`05add438ba041defc98d791038ae593d3f09352677cae43f2276d494205ce415`).
 The descriptor-derived test owns these full inventories; the tables here record

--- a/architecture/security-policy.md
+++ b/architecture/security-policy.md
@@ -293,21 +293,23 @@ After any successful policy write, pending chunks already covered by the new
 live effective policy are rejected as redundant. This keeps the review inbox
 aligned with what the sandbox currently enforces.
 
-Endpoint and binary advisor markers are provenance, not authorization or
-connection metadata. Provider- or user-authored declarations carry explicit
-provenance; `policy.local` declarations carry advisor provenance. A difference
-in endpoint provenance alone is compatible during effective-policy ambiguity
-validation. When identical endpoint or binary identities merge, an explicit
-declaration dominates an advisor declaration. Proposal coverage likewise
-ignores provenance so an approved overlay converges when an existing explicit
-declaration already supplies the same identity.
+Endpoint advisor markers are provenance, not authorization or connection
+metadata. Provider- or user-authored endpoints carry explicit provenance;
+`policy.local` endpoints carry advisor provenance. A difference in endpoint
+provenance alone is compatible during effective-policy ambiguity validation.
+When identical endpoints merge, an explicit declaration dominates an advisor
+declaration. Proposal coverage likewise ignores provenance so an approved
+overlay converges when an existing explicit declaration already supplies the
+same identity.
 
 This compatibility does not weaken SSRF classification. Exact-host trust
-requires one matching rule to contain both an exact explicit endpoint and an
-explicit binary identity. An advisor-only endpoint or binary cannot assemble
-that trust from unrelated rules. A provider rule may independently establish
-trust for its own explicit endpoint and binary pair, but an advisor overlay
-does not broaden that pair to a different binary.
+requires one matching rule to contain both an exact explicit endpoint and a
+matching binary identity. An advisor endpoint cannot assemble that trust from
+an unrelated explicit endpoint. When the advisor observes a new binary for an
+existing explicit endpoint contract, canonicalization keeps the observation in
+a separate rule whose endpoint retains advisor provenance. A provider or user
+rule may independently establish trust for its own explicit endpoint and binary
+pair, but an advisor overlay does not broaden that pair to a different binary.
 
 ### Security-notes gate
 

--- a/crates/openshell-cli/src/policy_update.rs
+++ b/crates/openshell-cli/src/policy_update.rs
@@ -60,10 +60,7 @@ pub fn build_policy_update_plan(
             endpoints: vec![endpoint.clone()],
             binaries: deduped_binaries
                 .iter()
-                .map(|path| NetworkBinary {
-                    path: path.clone(),
-                    ..Default::default()
-                })
+                .map(|path| NetworkBinary { path: path.clone() })
                 .collect(),
         };
         merge_operations.push(PolicyMergeOperation {

--- a/crates/openshell-cli/tests/provider_commands_integration.rs
+++ b/crates/openshell-cli/tests/provider_commands_integration.rs
@@ -2560,7 +2560,6 @@ binaries: [/usr/bin/yaml-client]
 }
 
 #[tokio::test]
-#[allow(deprecated)]
 async fn provider_profile_import_preserves_advanced_network_policy_fields() {
     let ts = run_server().await;
     let dir = tempfile::tempdir().unwrap();
@@ -2589,7 +2588,6 @@ endpoints:
     path: /v1
 binaries:
   - path: /usr/bin/advanced
-    harness: true
 ",
     )
     .unwrap();
@@ -2618,7 +2616,7 @@ binaries:
     assert_eq!(endpoint.allowed_ips, vec!["10.0.0.0/24"]);
     assert!(endpoint.allow_encoded_slash);
     assert_eq!(endpoint.path, "/v1");
-    assert!(profile.binaries[0].harness);
+    assert_eq!(profile.binaries[0].path, "/usr/bin/advanced");
 }
 
 #[tokio::test]

--- a/crates/openshell-core/src/proto/mod.rs
+++ b/crates/openshell-core/src/proto/mod.rs
@@ -94,3 +94,93 @@ pub fn all_workspaces_selector() -> WorkspaceSelector {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use prost::Message;
+
+    use super::SandboxPolicy;
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyNetworkBinary {
+        #[prost(string, tag = "1")]
+        path: String,
+        #[prost(bool, tag = "2")]
+        harness: bool,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyNetworkPolicyRule {
+        #[prost(message, repeated, tag = "3")]
+        binaries: Vec<LegacyNetworkBinary>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacySandboxPolicy {
+        #[prost(map = "string, message", tag = "5")]
+        network_policies: HashMap<String, LegacyNetworkPolicyRule>,
+    }
+
+    #[test]
+    fn sandbox_policy_ignores_removed_network_binary_harness_wire_field() {
+        let legacy = LegacySandboxPolicy {
+            network_policies: HashMap::from([(
+                "legacy".to_string(),
+                LegacyNetworkPolicyRule {
+                    binaries: vec![LegacyNetworkBinary {
+                        path: "/usr/bin/curl".to_string(),
+                        harness: true,
+                    }],
+                },
+            )]),
+        };
+
+        let decoded = SandboxPolicy::decode(legacy.encode_to_vec().as_slice())
+            .expect("legacy policy should decode");
+        assert_eq!(
+            decoded.network_policies["legacy"].binaries[0].path,
+            "/usr/bin/curl"
+        );
+
+        let round_tripped =
+            LegacySandboxPolicy::decode(decoded.encode_to_vec().as_slice()).unwrap();
+        assert!(!round_tripped.network_policies["legacy"].binaries[0].harness);
+    }
+
+    #[test]
+    fn network_binary_reserves_removed_harness_name_and_tag() {
+        let descriptor = prost_types::FileDescriptorSet::decode(crate::FILE_DESCRIPTOR_SET)
+            .expect("descriptor set should decode");
+        let network_binary = descriptor
+            .file
+            .iter()
+            .find(|file| file.package.as_deref() == Some("openshell.sandbox.v1"))
+            .and_then(|file| {
+                file.message_type
+                    .iter()
+                    .find(|message| message.name.as_deref() == Some("NetworkBinary"))
+            })
+            .expect("NetworkBinary descriptor should exist");
+
+        assert!(
+            network_binary
+                .field
+                .iter()
+                .all(|field| field.name.as_deref() != Some("harness"))
+        );
+        assert!(
+            network_binary
+                .reserved_range
+                .iter()
+                .any(|range| range.start == Some(2) && range.end == Some(3))
+        );
+        assert!(
+            network_binary
+                .reserved_name
+                .iter()
+                .any(|name| name == "harness")
+        );
+    }
+}

--- a/crates/openshell-core/src/proto/mod.rs
+++ b/crates/openshell-core/src/proto/mod.rs
@@ -103,6 +103,15 @@ mod tests {
 
     use super::SandboxPolicy;
 
+    // SandboxPolicy payload encoded by the pre-0.1.0 schema with
+    // NetworkBinary.harness=true. Keep this fixed fixture to prove that the
+    // current schema continues to accept the former durable wire format.
+    const LEGACY_SANDBOX_POLICY_WITH_HARNESS: &[u8] = &[
+        0x2a, 0x1d, 0x0a, 0x06, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x12, 0x13, 0x1a, 0x11, 0x0a,
+        0x0d, 0x2f, 0x75, 0x73, 0x72, 0x2f, 0x62, 0x69, 0x6e, 0x2f, 0x63, 0x75, 0x72, 0x6c, 0x10,
+        0x01,
+    ];
+
     #[derive(Clone, PartialEq, Message)]
     struct LegacyNetworkBinary {
         #[prost(string, tag = "1")]
@@ -137,8 +146,10 @@ mod tests {
             )]),
         };
 
-        let decoded = SandboxPolicy::decode(legacy.encode_to_vec().as_slice())
-            .expect("legacy policy should decode");
+        assert_eq!(legacy.encode_to_vec(), LEGACY_SANDBOX_POLICY_WITH_HARNESS);
+
+        let decoded = SandboxPolicy::decode(LEGACY_SANDBOX_POLICY_WITH_HARNESS)
+            .expect("legacy policy fixture should decode");
         assert_eq!(
             decoded.network_policies["legacy"].binaries[0].path,
             "/usr/bin/curl"

--- a/crates/openshell-driver-mxc/src/policy.rs
+++ b/crates/openshell-driver-mxc/src/policy.rs
@@ -271,7 +271,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".into(),
-                    ..Default::default()
                 }],
             },
         );

--- a/crates/openshell-driver-mxc/tests/policy_mapper_matrix.rs
+++ b/crates/openshell-driver-mxc/tests/policy_mapper_matrix.rs
@@ -766,11 +766,9 @@ fn b_binaries_error_per_binary() {
             binaries: vec![
                 NetworkBinary {
                     path: "/usr/bin/curl".into(),
-                    ..Default::default()
                 },
                 NetworkBinary {
                     path: "/usr/bin/wget".into(),
-                    ..Default::default()
                 },
             ],
         },
@@ -1248,7 +1246,6 @@ fn handled_fields_inventory() {
                     endpoints: vec![full_ep, single_port_ep],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".into(),
-                        ..Default::default()
                     }],
                 },
             );

--- a/crates/openshell-policy/src/ambiguity.rs
+++ b/crates/openshell-policy/src/ambiguity.rs
@@ -726,7 +726,6 @@ mod tests {
                 endpoints: vec![left],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -737,7 +736,6 @@ mod tests {
                 endpoints: vec![right],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/bash".to_string(),
-                    ..Default::default()
                 }],
             },
         );

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -5014,7 +5014,7 @@ network_policies:
         let error = parse_sandbox_policy(yaml).expect_err("removed harness field must be rejected");
         let error_debug = format!("{error:?}");
         assert!(
-            error_debug.contains("unknown field `harness`"),
+            error_debug.contains("unknown field") && error_debug.contains("harness"),
             "unexpected error: {error_debug}"
         );
     }

--- a/crates/openshell-policy/src/lib.rs
+++ b/crates/openshell-policy/src/lib.rs
@@ -467,10 +467,6 @@ struct L7DenyRuleDef {
 #[serde(deny_unknown_fields)]
 struct NetworkBinaryDef {
     path: String,
-    /// Deprecated: ignored. Kept for backward compat with existing YAML files.
-    #[serde(default, skip_serializing)]
-    #[allow(dead_code)]
-    harness: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -908,10 +904,7 @@ fn to_proto(raw: PolicyFile) -> Result<SandboxPolicy> {
                 binaries: rule
                     .binaries
                     .into_iter()
-                    .map(|b| NetworkBinary {
-                        path: b.path,
-                        ..Default::default()
-                    })
+                    .map(|b| NetworkBinary { path: b.path })
                     .collect(),
             };
             (key, proto_rule)
@@ -1079,7 +1072,6 @@ fn from_proto(policy: &SandboxPolicy) -> Result<PolicyFile> {
                     .iter()
                     .map(|b| NetworkBinaryDef {
                         path: b.path.clone(),
-                        harness: false,
                     })
                     .collect(),
             };
@@ -5003,6 +4995,28 @@ network_policies:
             bogus: true
 ";
         assert!(parse_sandbox_policy(yaml).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_removed_network_binary_harness_field() {
+        let yaml = r"
+version: 1
+network_policies:
+  legacy:
+    endpoints:
+      - host: example.com
+        port: 443
+    binaries:
+      - path: /usr/bin/curl
+        harness: true
+";
+
+        let error = parse_sandbox_policy(yaml).expect_err("removed harness field must be rejected");
+        let error_debug = format!("{error:?}");
+        assert!(
+            error_debug.contains("unknown field `harness`"),
+            "unexpected error: {error_debug}"
+        );
     }
 
     #[test]

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -1531,10 +1531,11 @@ fn merge_endpoint(
     existing.websocket_credential_rewrite |= incoming.websocket_credential_rewrite;
     existing.request_body_credential_rewrite |= incoming.request_body_credential_rewrite;
     existing.allow_uninspected_credentials |= incoming.allow_uninspected_credentials;
-    // Provenance is not an authorization bit. If either declaration came
-    // directly from a user or provider, keep the endpoint explicit. This
-    // mirrors binary provenance and prevents an advisor overlay from tainting
-    // an already explicit endpoint for exact-host SSRF evaluation.
+    // If either declaration came directly from a user or provider, keep the
+    // endpoint explicit. Clearing advisor provenance changes exact-host SSRF
+    // trust, so `ensure_authorization_inheritance_is_declared` only permits
+    // this transition when the incoming rule declares the existing binaries
+    // that will receive that trust.
     existing.advisor_proposed &= incoming.advisor_proposed;
     normalize_endpoint(existing);
     Ok(())
@@ -1810,7 +1811,13 @@ fn authorization_unit_unchanged(
     merged: &NetworkEndpoint,
     port: Option<u32>,
 ) -> bool {
-    endpoint_authorization_covers_port(existing, merged, port)
+    // Advisor provenance affects whether an exact hostname may resolve to a
+    // private address. Treat clearing it as an authorization change even
+    // though proposal coverage deliberately ignores provenance. Otherwise an
+    // explicit rule for one binary could make advisor-observed binaries on the
+    // same rule eligible for private-address access.
+    existing.advisor_proposed == merged.advisor_proposed
+        && endpoint_authorization_covers_port(existing, merged, port)
         && endpoint_authorization_covers_port(merged, existing, port)
 }
 
@@ -4764,6 +4771,84 @@ mod tests {
         let advisor = &result.policy.network_policies["allow_index_crates_io_443"];
         assert!(advisor.endpoints[0].advisor_proposed);
         assert_eq!(advisor.binaries, vec![binary("/usr/bin/curl")]);
+    }
+
+    #[test]
+    fn add_rule_keeps_explicit_binary_separate_from_advisor_endpoint() {
+        let mut advisor_endpoint = endpoint("index.crates.io", 443);
+        advisor_endpoint.advisor_proposed = true;
+        let mut policy = restrictive_default_policy();
+        policy.network_policies.insert(
+            "advisor_index".to_string(),
+            NetworkPolicyRule {
+                name: "advisor-index".to_string(),
+                endpoints: vec![advisor_endpoint],
+                binaries: vec![binary("/usr/bin/curl")],
+            },
+        );
+
+        let result = merge_policy(
+            policy,
+            &[PolicyMergeOp::AddRule {
+                rule_name: "explicit_index".to_string(),
+                rule: NetworkPolicyRule {
+                    name: "explicit-index".to_string(),
+                    endpoints: vec![endpoint("index.crates.io", 443)],
+                    binaries: vec![binary("/usr/bin/wget")],
+                },
+            }],
+        )
+        .expect("explicit authorization should remain separate");
+
+        let advisor = &result.policy.network_policies["advisor_index"];
+        assert!(advisor.endpoints[0].advisor_proposed);
+        assert_eq!(advisor.binaries, vec![binary("/usr/bin/curl")]);
+
+        let explicit = &result.policy.network_policies["explicit_index"];
+        assert!(!explicit.endpoints[0].advisor_proposed);
+        assert_eq!(explicit.binaries, vec![binary("/usr/bin/wget")]);
+        assert!(result.warnings.iter().any(|warning| matches!(
+            warning,
+            PolicyMergeWarning::KeptRequestedRuleNameToAvoidWidening {
+                rule_name,
+                overlapping_rule_name,
+                ..
+            } if rule_name == "explicit_index" && overlapping_rule_name == "advisor_index"
+        )));
+    }
+
+    #[test]
+    fn add_rule_rejects_clearing_advisor_provenance_for_undeclared_binary() {
+        let mut advisor_endpoint = endpoint("index.crates.io", 443);
+        advisor_endpoint.advisor_proposed = true;
+        let policy = policy_with_rule(
+            "advisor_index",
+            NetworkPolicyRule {
+                name: "advisor-index".to_string(),
+                endpoints: vec![advisor_endpoint],
+                binaries: vec![binary("/usr/bin/curl")],
+            },
+        );
+
+        let result = merge_policy(
+            policy,
+            &[PolicyMergeOp::AddRule {
+                rule_name: "advisor_index".to_string(),
+                rule: NetworkPolicyRule {
+                    name: "advisor-index".to_string(),
+                    endpoints: vec![endpoint("index.crates.io", 443)],
+                    binaries: vec![binary("/usr/bin/wget")],
+                },
+            }],
+        );
+
+        assert!(matches!(
+            result,
+            Err(PolicyMergeError::ExistingBinariesWouldInheritAuthorization {
+                undeclared_binaries,
+                ..
+            }) if undeclared_binaries == ["/usr/bin/curl"]
+        ));
     }
 
     fn endpoint_with_ports(host: &str, ports: &[u32]) -> NetworkEndpoint {

--- a/crates/openshell-policy/src/merge.rs
+++ b/crates/openshell-policy/src/merge.rs
@@ -20,8 +20,11 @@ const DEFAULT_JSON_RPC_MAX_BODY_BYTES: u32 = 64 * 1024;
 /// has one unambiguous endpoint contract, proposing a second generic L4
 /// endpoint loses inspection metadata and can make the effective policy
 /// ambiguous. Preserve the existing contract instead. Sandbox-owned rules are
-/// expanded in place; provider-owned rules remain immutable and are mirrored
-/// into the requested sandbox-owned overlay.
+/// expanded in place only when they already authorize the observed binaries.
+/// A new advisor-observed binary stays in a separate endpoint-provenance-marked
+/// rule so it cannot inherit exact-host private-address trust. Provider-owned
+/// rules remain immutable and are mirrored into the requested sandbox-owned
+/// overlay.
 pub fn canonicalize_advisor_add_rule(
     base_policy: &SandboxPolicy,
     effective_policy: &SandboxPolicy,
@@ -84,30 +87,52 @@ pub fn canonicalize_advisor_add_rule(
         .iter()
         .filter(|(name, _)| !is_provider_rule_name(name))
         .filter_map(|(name, rule)| {
-            rule.endpoints
+            (rule.endpoints.iter().any(|endpoint| {
+                let mut normalized = endpoint.clone();
+                normalized.provider_credentialed = false;
+                normalized.advisor_proposed = false;
+                normalize_endpoint(&mut normalized);
+                normalized == contract
+            }) && incoming_rule
+                .binaries
                 .iter()
-                .any(|endpoint| {
-                    let mut normalized = endpoint.clone();
-                    normalized.provider_credentialed = false;
-                    normalized.advisor_proposed = false;
-                    normalize_endpoint(&mut normalized);
-                    normalized == contract
-                })
-                .then_some(name.clone())
+                .all(|binary| binary_scope_covers(rule, binary)))
+            .then_some(name.clone())
         })
         .collect::<Vec<_>>();
     sandbox_owners.sort();
 
     let mut contract = contract;
-    if sandbox_owners.is_empty() {
+    let target_name = if let Some(owner) = sandbox_owners.first() {
+        if let Some(endpoint) =
+            base_policy.network_policies[owner]
+                .endpoints
+                .iter()
+                .find(|endpoint| {
+                    let mut normalized = (*endpoint).clone();
+                    normalized.provider_credentialed = false;
+                    normalized.advisor_proposed = false;
+                    normalize_endpoint(&mut normalized);
+                    normalized == contract
+                })
+        {
+            contract.advisor_proposed = endpoint.advisor_proposed;
+        }
+        owner.clone()
+    } else {
         // A provider-owned contract is mirrored into a new sandbox-owned
         // advisor overlay, so retain the incoming proposal provenance.
         contract.advisor_proposed = incoming_endpoint.advisor_proposed;
-    }
-    let target_name = sandbox_owners
-        .first()
-        .cloned()
-        .unwrap_or_else(|| requested_rule_name.to_string());
+        let mut candidate = requested_rule_name.to_string();
+        let mut suffix = 2_u32;
+        while base_policy.network_policies.contains_key(&candidate)
+            || effective_policy.network_policies.contains_key(&candidate)
+        {
+            candidate = format!("{requested_rule_name}_{suffix}");
+            suffix += 1;
+        }
+        candidate
+    };
     let mut canonical = incoming_rule.clone();
     canonical.name.clone_from(&target_name);
     canonical.endpoints = vec![contract];
@@ -1153,10 +1178,13 @@ fn add_rule(
         incoming_rule.name = rule_name.to_string();
     }
 
-    // Endpoint-overlap fallback: when a chunk arrives with a new rule_name
-    // that doesn't already exist, fold it into a same-host/port rule if one
-    // is present. This is intentional for user-authored policies (incremental
-    // refinements live under one rule name).
+    // Endpoint-overlap fallback: when an explicit chunk arrives with a new
+    // rule_name that doesn't already exist, fold it into a same-host/port rule
+    // if one is present. This is intentional for user-authored policies
+    // (incremental refinements live under one rule name). Advisor-proposed
+    // endpoints must stay on their requested key: folding one into an explicit
+    // endpoint would clear its provenance and let a newly observed binary
+    // inherit exact-host private-address trust.
     //
     // Provider-injected rules (`_provider_*` — see `compose.rs::provider_rule_name`)
     // are deliberately EXCLUDED from this fallback. Provider profiles supply a
@@ -1171,7 +1199,11 @@ fn add_rule(
     let requested_key_exists = policy.network_policies.contains_key(rule_name);
     let target_key = if requested_key_exists {
         Some(rule_name.to_string())
-    } else {
+    } else if incoming_rule
+        .endpoints
+        .iter()
+        .all(|endpoint| !endpoint.advisor_proposed)
+    {
         let mut keys: Vec<_> = policy.network_policies.keys().cloned().collect();
         keys.sort();
         keys.into_iter()
@@ -1184,6 +1216,8 @@ fn add_rule(
                         rules_share_endpoint(existing_rule, &incoming_rule)
                     })
             })
+    } else {
+        None
     };
 
     match target_key {
@@ -2054,12 +2088,6 @@ fn expand_access_preset(protocol: &str, access: &str) -> Option<Vec<L7Rule>> {
 fn append_unique_binaries(existing: &mut Vec<NetworkBinary>, incoming: &[NetworkBinary]) {
     let mut seen: HashSet<String> = existing.iter().map(|binary| binary.path.clone()).collect();
     for binary in incoming {
-        if let Some(existing_binary) = existing.iter_mut().find(|item| item.path == binary.path) {
-            if !is_advisor_proposed_binary(binary) {
-                mark_user_declared_binary(existing_binary);
-            }
-            continue;
-        }
         if seen.insert(binary.path.clone()) {
             existing.push(binary.clone());
         }
@@ -2118,30 +2146,8 @@ fn dedup_strings(values: &mut Vec<String>) {
 }
 
 fn dedup_binaries(values: &mut Vec<NetworkBinary>) {
-    let mut deduped: Vec<NetworkBinary> = Vec::with_capacity(values.len());
-    for binary in std::mem::take(values) {
-        if let Some(existing) = deduped.iter_mut().find(|item| item.path == binary.path) {
-            if !is_advisor_proposed_binary(&binary) {
-                mark_user_declared_binary(existing);
-            }
-        } else {
-            deduped.push(binary);
-        }
-    }
-    *values = deduped;
-}
-
-fn is_advisor_proposed_binary(binary: &NetworkBinary) -> bool {
-    #[allow(deprecated)]
-    let advisor_proposed = binary.harness;
-    advisor_proposed
-}
-
-fn mark_user_declared_binary(binary: &mut NetworkBinary) {
-    #[allow(deprecated)]
-    {
-        binary.harness = false;
-    }
+    let mut seen = HashSet::new();
+    values.retain(|binary| seen.insert(binary.path.clone()));
 }
 
 fn dedup_l7_rules(values: &mut Vec<L7Rule>) {
@@ -2248,18 +2254,6 @@ mod tests {
         }
     }
 
-    fn advisor_binary(path: &str) -> NetworkBinary {
-        let mut binary = NetworkBinary {
-            path: path.to_string(),
-            ..Default::default()
-        };
-        #[allow(deprecated)]
-        {
-            binary.harness = true;
-        }
-        binary
-    }
-
     fn rest_rule(method: &str, path: &str) -> L7Rule {
         L7Rule {
             allow: Some(L7Allow {
@@ -2276,7 +2270,7 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_advisor_expands_existing_inspected_rule_without_l7_downgrade() {
+    fn canonicalize_advisor_keeps_new_binary_separate_from_explicit_rule() {
         let mut existing_endpoint = endpoint("index.crates.io", 443);
         existing_endpoint.protocol = "rest".to_string();
         existing_endpoint.enforcement = "enforce".to_string();
@@ -2286,7 +2280,6 @@ mod tests {
             endpoints: vec![existing_endpoint.clone()],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/cargo".to_string(),
-                ..Default::default()
             }],
         };
         let mut base = SandboxPolicy::default();
@@ -2298,7 +2291,7 @@ mod tests {
         let incoming = NetworkPolicyRule {
             name: "allow_index_crates_io_443".to_string(),
             endpoints: vec![observed],
-            binaries: vec![advisor_binary("/usr/bin/curl")],
+            binaries: vec![binary("/usr/bin/curl")],
         };
 
         let (rule_name, canonical) = canonicalize_advisor_add_rule(
@@ -2309,13 +2302,116 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(rule_name, "cargo_registry");
-        assert_eq!(canonical.endpoints, vec![existing_endpoint]);
+        assert_eq!(rule_name, "allow_index_crates_io_443");
+        assert_eq!(canonical.endpoints[0].protocol, existing_endpoint.protocol);
+        assert_eq!(canonical.endpoints[0].access, existing_endpoint.access);
+        assert!(canonical.endpoints[0].advisor_proposed);
         assert_eq!(canonical.binaries[0].path, "/usr/bin/curl");
-        #[allow(deprecated)]
-        {
-            assert!(canonical.binaries[0].harness);
-        }
+    }
+
+    #[test]
+    fn canonicalize_advisor_avoids_explicit_requested_key_collision() {
+        let mut base = SandboxPolicy::default();
+        base.network_policies.insert(
+            "allow_index_crates_io_443".to_string(),
+            NetworkPolicyRule {
+                name: "explicit-index".to_string(),
+                endpoints: vec![endpoint("index.crates.io", 443)],
+                binaries: vec![binary("/usr/bin/cargo")],
+            },
+        );
+        let incoming = NetworkPolicyRule {
+            name: "allow_index_crates_io_443".to_string(),
+            endpoints: vec![NetworkEndpoint {
+                host: "index.crates.io".to_string(),
+                port: 443,
+                advisor_proposed: true,
+                ..Default::default()
+            }],
+            binaries: vec![binary("/usr/bin/curl")],
+        };
+
+        let (rule_name, canonical) =
+            canonicalize_advisor_add_rule(&base, &base, "allow_index_crates_io_443", &incoming)
+                .unwrap();
+        assert_eq!(rule_name, "allow_index_crates_io_443_2");
+        assert!(canonical.endpoints[0].advisor_proposed);
+
+        let merged = merge_policy(
+            base,
+            &[PolicyMergeOp::AddRule {
+                rule_name: rule_name.clone(),
+                rule: canonical,
+            }],
+        )
+        .unwrap();
+        assert_eq!(
+            merged.policy.network_policies["allow_index_crates_io_443"].binaries,
+            vec![binary("/usr/bin/cargo")]
+        );
+        assert!(merged.policy.network_policies[&rule_name].endpoints[0].advisor_proposed);
+    }
+
+    #[test]
+    fn canonicalize_advisor_reuses_explicit_rule_for_existing_binary() {
+        let existing_endpoint = endpoint("index.crates.io", 443);
+        let existing = NetworkPolicyRule {
+            name: "cargo-registry".to_string(),
+            endpoints: vec![existing_endpoint],
+            binaries: vec![binary("/usr/bin/curl")],
+        };
+        let mut base = SandboxPolicy::default();
+        base.network_policies
+            .insert("cargo_registry".to_string(), existing);
+        let incoming = NetworkPolicyRule {
+            name: "allow_index_crates_io_443".to_string(),
+            endpoints: vec![NetworkEndpoint {
+                host: "index.crates.io".to_string(),
+                port: 443,
+                advisor_proposed: true,
+                ..Default::default()
+            }],
+            binaries: vec![binary("/usr/bin/curl")],
+        };
+
+        let (rule_name, canonical) =
+            canonicalize_advisor_add_rule(&base, &base, "allow_index_crates_io_443", &incoming)
+                .unwrap();
+
+        assert_eq!(rule_name, "cargo_registry");
+        assert!(!canonical.endpoints[0].advisor_proposed);
+    }
+
+    #[test]
+    fn canonicalize_advisor_preserves_existing_advisor_endpoint_provenance() {
+        let mut advisor_endpoint = endpoint("index.crates.io", 443);
+        advisor_endpoint.advisor_proposed = true;
+        let mut base = SandboxPolicy::default();
+        base.network_policies.insert(
+            "advisor_index".to_string(),
+            NetworkPolicyRule {
+                name: "advisor-index".to_string(),
+                endpoints: vec![advisor_endpoint],
+                binaries: vec![binary("/usr/bin/curl")],
+            },
+        );
+        let incoming = NetworkPolicyRule {
+            name: "allow_index_crates_io_443".to_string(),
+            endpoints: vec![NetworkEndpoint {
+                host: "index.crates.io".to_string(),
+                port: 443,
+                advisor_proposed: true,
+                ..Default::default()
+            }],
+            binaries: vec![binary("/usr/bin/curl")],
+        };
+
+        let (rule_name, canonical) =
+            canonicalize_advisor_add_rule(&base, &base, "allow_index_crates_io_443", &incoming)
+                .unwrap();
+
+        assert_eq!(rule_name, "advisor_index");
+        assert!(canonical.endpoints[0].advisor_proposed);
     }
 
     #[test]
@@ -2343,7 +2439,7 @@ mod tests {
                 advisor_proposed: true,
                 ..Default::default()
             }],
-            binaries: vec![advisor_binary("/usr/bin/curl")],
+            binaries: vec![binary("/usr/bin/curl")],
         };
 
         let (rule_name, canonical) =
@@ -2378,7 +2474,7 @@ mod tests {
             NetworkPolicyRule {
                 name: "existing-advisor".to_string(),
                 endpoints: vec![advisor_endpoint],
-                binaries: vec![advisor_binary("/usr/bin/curl")],
+                binaries: vec![binary("/usr/bin/curl")],
             },
         );
 
@@ -2400,16 +2496,17 @@ mod tests {
                 advisor_proposed: true,
                 ..Default::default()
             }],
-            binaries: vec![advisor_binary("/usr/bin/python")],
+            binaries: vec![binary("/usr/bin/python")],
         };
 
         let (rule_name, canonical) =
             canonicalize_advisor_add_rule(&base, &effective, "advisor_example", &incoming)
                 .expect("provenance alone must not create multiple endpoint contracts");
 
-        assert_eq!(rule_name, "existing_advisor");
+        assert_eq!(rule_name, "advisor_example");
         assert_eq!(canonical.endpoints[0].protocol, "rest");
         assert_eq!(canonical.endpoints[0].access, "read-only");
+        assert!(canonical.endpoints[0].advisor_proposed);
     }
 
     #[test]
@@ -2437,7 +2534,7 @@ mod tests {
                 advisor_proposed: true,
                 ..Default::default()
             }],
-            binaries: vec![advisor_binary("/usr/bin/curl")],
+            binaries: vec![binary("/usr/bin/curl")],
         };
 
         let (rule_name, canonical) = canonicalize_advisor_add_rule(
@@ -2479,7 +2576,6 @@ mod tests {
     fn binary(path: &str) -> NetworkBinary {
         NetworkBinary {
             path: path.to_string(),
-            ..Default::default()
         }
     }
 
@@ -3663,7 +3759,6 @@ mod tests {
                 endpoints: vec![endpoint("api.github.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -3700,14 +3795,14 @@ mod tests {
     }
 
     #[test]
-    fn add_rule_user_binary_clears_advisor_marker_for_same_path() {
+    fn add_rule_deduplicates_binary_path() {
         let mut policy = restrictive_default_policy();
         policy.network_policies.insert(
             "existing".to_string(),
             NetworkPolicyRule {
                 name: "existing".to_string(),
                 endpoints: vec![endpoint("api.github.com", 443)],
-                binaries: vec![advisor_binary("/usr/bin/curl")],
+                binaries: vec![binary("/usr/bin/curl")],
             },
         );
 
@@ -3716,7 +3811,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -3731,22 +3825,18 @@ mod tests {
 
         let rule = &result.policy.network_policies["existing"];
         assert_eq!(rule.binaries.len(), 1);
-        #[allow(deprecated)]
-        {
-            assert!(!rule.binaries[0].harness);
-        }
+        assert_eq!(rule.binaries[0].path, "/usr/bin/curl");
     }
 
     #[test]
-    fn add_rule_duplicate_binaries_prefer_user_declared_marker() {
+    fn add_rule_deduplicates_binary_paths_within_incoming_rule() {
         let incoming = NetworkPolicyRule {
             name: "incoming".to_string(),
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![
-                advisor_binary("/usr/bin/curl"),
+                binary("/usr/bin/curl"),
                 NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 },
             ],
         };
@@ -3762,10 +3852,7 @@ mod tests {
 
         let rule = &result.policy.network_policies["github"];
         assert_eq!(rule.binaries.len(), 1);
-        #[allow(deprecated)]
-        {
-            assert!(!rule.binaries[0].harness);
-        }
+        assert_eq!(rule.binaries[0].path, "/usr/bin/curl");
     }
 
     #[test]
@@ -3778,7 +3865,6 @@ mod tests {
                 endpoints: vec![endpoint("api.example.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/python".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -3792,7 +3878,7 @@ mod tests {
                 advisor_proposed: true,
                 ..Default::default()
             }],
-            binaries: vec![advisor_binary("/usr/bin/python")],
+            binaries: vec![binary("/usr/bin/python")],
         };
 
         let result = merge_policy(
@@ -3806,13 +3892,7 @@ mod tests {
 
         let rule = &result.policy.network_policies["app-api"];
         assert_eq!(rule.binaries.len(), 1, "binary should still dedupe");
-        #[allow(deprecated)]
-        {
-            assert!(
-                !rule.binaries[0].harness,
-                "existing user binary provenance should be retained"
-            );
-        }
+        assert_eq!(rule.binaries[0].path, "/usr/bin/python");
         let internal_endpoint = rule
             .endpoints
             .iter()
@@ -4162,7 +4242,6 @@ mod tests {
                 endpoints: vec![endpoint("api.github.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/gh".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4186,7 +4265,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4209,7 +4287,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4239,7 +4316,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4251,7 +4327,6 @@ mod tests {
                 endpoints: vec![endpoint("api.github.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/git".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4282,7 +4357,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4297,7 +4371,6 @@ mod tests {
                 endpoints: vec![endpoint("api.github.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/git".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4333,7 +4406,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4352,7 +4424,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4379,7 +4450,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4401,7 +4471,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4424,7 +4493,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/git".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -4458,7 +4526,6 @@ mod tests {
                 endpoints: vec![endpoint("api.github.com", 443)],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4523,7 +4590,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/gh".to_string(),
-                ..Default::default()
             }],
         };
         let composed = compose_effective_policy(
@@ -4554,7 +4620,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let result = merge_policy(
@@ -4622,7 +4687,6 @@ mod tests {
             endpoints: vec![endpoint("api.github.com", 443)],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let result = merge_policy(
@@ -4664,6 +4728,42 @@ mod tests {
             "got warnings: {:?}",
             result.warnings
         );
+    }
+
+    #[test]
+    fn add_rule_keeps_advisor_binary_separate_from_explicit_endpoint() {
+        let mut policy = restrictive_default_policy();
+        policy.network_policies.insert(
+            "cargo_registry".to_string(),
+            NetworkPolicyRule {
+                name: "cargo-registry".to_string(),
+                endpoints: vec![endpoint("index.crates.io", 443)],
+                binaries: vec![binary("/usr/bin/cargo")],
+            },
+        );
+
+        let mut advisor_endpoint = endpoint("index.crates.io", 443);
+        advisor_endpoint.advisor_proposed = true;
+        let result = merge_policy(
+            policy,
+            &[PolicyMergeOp::AddRule {
+                rule_name: "allow_index_crates_io_443".to_string(),
+                rule: NetworkPolicyRule {
+                    name: "allow_index_crates_io_443".to_string(),
+                    endpoints: vec![advisor_endpoint],
+                    binaries: vec![binary("/usr/bin/curl")],
+                },
+            }],
+        )
+        .expect("advisor rule should remain separate");
+
+        let explicit = &result.policy.network_policies["cargo_registry"];
+        assert!(!explicit.endpoints[0].advisor_proposed);
+        assert_eq!(explicit.binaries, vec![binary("/usr/bin/cargo")]);
+
+        let advisor = &result.policy.network_policies["allow_index_crates_io_443"];
+        assert!(advisor.endpoints[0].advisor_proposed);
+        assert_eq!(advisor.binaries, vec![binary("/usr/bin/curl")]);
     }
 
     fn endpoint_with_ports(host: &str, ports: &[u32]) -> NetworkEndpoint {

--- a/crates/openshell-providers/src/profiles.rs
+++ b/crates/openshell-providers/src/profiles.rs
@@ -3,8 +3,6 @@
 
 //! Declarative provider type profiles.
 
-#![allow(deprecated)] // NetworkBinary::harness remains in the public proto for compatibility.
-
 use openshell_core::mcp::{DEFAULT_MCP_PROTOCOL_VERSION, McpProtocolVersion};
 use openshell_core::proto::{
     GraphqlOperation, L7Allow, L7DenyRule, L7QueryMatcher, L7Rule, McpOptions, NetworkBinary,
@@ -19,7 +17,6 @@ use openshell_policy::{
     L7EndpointFields, L7Protocol, validate_explicit_tcp_additional_fields,
     validate_l7_endpoint_semantics,
 };
-use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::net::IpAddr;
@@ -591,7 +588,6 @@ pub struct GraphqlOperationProfile {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryProfile {
     pub path: String,
-    pub harness: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1032,13 +1028,7 @@ impl Serialize for BinaryProfile {
     where
         S: Serializer,
     {
-        if !self.harness {
-            return serializer.serialize_str(&self.path);
-        }
-        let mut state = serializer.serialize_struct("BinaryProfile", 2)?;
-        state.serialize_field("path", &self.path)?;
-        state.serialize_field("harness", &self.harness)?;
-        state.end()
+        serializer.serialize_str(&self.path)
     }
 }
 
@@ -1057,19 +1047,23 @@ impl<'de> Deserialize<'de> for BinaryProfile {
         #[derive(Deserialize)]
         struct BinaryProfileObject {
             path: String,
-            #[serde(default)]
-            harness: bool,
+            #[serde(flatten)]
+            extra: HashMap<String, serde_json::Value>,
         }
 
         match BinaryProfileInput::deserialize(deserializer)? {
-            BinaryProfileInput::Path(path) => Ok(Self {
-                path,
-                harness: false,
-            }),
-            BinaryProfileInput::Object(binary) => Ok(Self {
-                path: binary.path,
-                harness: binary.harness,
-            }),
+            BinaryProfileInput::Path(path) => Ok(Self { path }),
+            BinaryProfileInput::Object(binary) => {
+                if !binary.extra.is_empty() {
+                    let mut fields = binary.extra.keys().cloned().collect::<Vec<_>>();
+                    fields.sort();
+                    return Err(de::Error::custom(format!(
+                        "unsupported provider profile binary fields: {}; binaries accept only 'path' and the deprecated 'harness' field was removed in 0.1.0",
+                        fields.join(", ")
+                    )));
+                }
+                Ok(Self { path: binary.path })
+            }
         }
     }
 }
@@ -1579,14 +1573,12 @@ fn canonicalize_mcp_profile_versions(versions: &mut [String]) {
 fn binary_to_proto(binary: &BinaryProfile) -> NetworkBinary {
     NetworkBinary {
         path: binary.path.clone(),
-        harness: binary.harness,
     }
 }
 
 fn binary_from_proto(binary: &NetworkBinary) -> BinaryProfile {
     BinaryProfile {
         path: binary.path.clone(),
-        harness: binary.harness,
     }
 }
 
@@ -5144,7 +5136,6 @@ endpoints:
     allow_uninspected_credentials: true
 binaries:
   - path: /usr/bin/custom
-    harness: true
 ",
         )
         .expect("profile should parse");
@@ -5186,10 +5177,11 @@ binaries:
             Some("GET")
         );
         assert_eq!(rest_ep.deny_rules[0].method, "POST");
-        assert!(proto.binaries[0].harness);
+        assert_eq!(proto.binaries[0].path, "/usr/bin/custom");
 
-        let reparsed = parse_profile_yaml(&profile_to_yaml(&profile).expect("serialize YAML"))
-            .expect("serialized profile should parse");
+        let serialized = profile_to_yaml(&profile).expect("serialize YAML");
+        assert!(serialized.contains("- /usr/bin/custom"));
+        let reparsed = parse_profile_yaml(&serialized).expect("serialized profile should parse");
         let reprotoo = reparsed.to_proto();
         assert_eq!(reprotoo.endpoints[0].access, "read-only");
         assert_eq!(reprotoo.endpoints[1].rules.len(), 1);
@@ -5197,7 +5189,28 @@ binaries:
         assert_eq!(reprotoo.endpoints[1].ports, vec![443, 8443]);
         assert!(reprotoo.endpoints[1].allow_uninspected_credentials);
         assert!(!reprotoo.endpoints[1].provider_credentialed);
-        assert!(reprotoo.binaries[0].harness);
+        assert_eq!(reprotoo.binaries[0].path, "/usr/bin/custom");
+    }
+
+    #[test]
+    fn profile_yaml_rejects_removed_binary_harness_field() {
+        let error = parse_profile_yaml(
+            r"
+id: legacy-binary
+display_name: Legacy binary
+binaries:
+  - path: /usr/bin/custom
+    harness: true
+",
+        )
+        .expect_err("removed harness field must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("'harness' field was removed in 0.1.0"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/openshell-sandbox/src/mechanistic_mapper.rs
+++ b/crates/openshell-sandbox/src/mechanistic_mapper.rs
@@ -145,17 +145,9 @@ pub fn generate_proposals(summaries: &[DenialSummary]) -> Vec<PolicyChunk> {
         let binaries: Vec<NetworkBinary> = if binary.is_empty() {
             vec![]
         } else {
-            let mut proposal_binary = NetworkBinary {
+            vec![NetworkBinary {
                 path: binary.clone(),
-                ..Default::default()
-            };
-            // The deprecated harness bit is ignored by policy YAML, but OPA
-            // maps it to advisor_proposed to preserve the SSRF two-step flow.
-            #[allow(deprecated)]
-            {
-                proposal_binary.harness = true;
-            }
-            vec![proposal_binary]
+            }]
         };
 
         let proposed_rule = NetworkPolicyRule {
@@ -535,10 +527,7 @@ mod tests {
         assert_eq!(rule.endpoints[0].port, 443);
         assert_eq!(rule.binaries.len(), 1);
         assert_eq!(rule.binaries[0].path, "/usr/bin/curl");
-        #[allow(deprecated)]
-        {
-            assert!(rule.binaries[0].harness);
-        }
+        assert!(rule.endpoints[0].advisor_proposed);
 
         // No L7 fields when no samples provided.
         assert!(rule.endpoints[0].protocol.is_empty());

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -114,6 +114,89 @@ const STORED_POLICY_SOURCE_GLOBAL: &str = "global policy setting";
 /// Maximum number of optimistic retry attempts for policy version conflicts.
 const MERGE_RETRY_LIMIT: usize = 5;
 
+// Private wire-only compatibility types for policy history written before
+// 0.1.0. Public generated bindings intentionally reserve NetworkBinary tag 2,
+// but stored policies still need its former advisor-provenance value migrated
+// before the unknown field is discarded.
+#[derive(Clone, PartialEq, Message)]
+struct LegacyStoredNetworkBinary {
+    #[prost(string, tag = "1")]
+    path: String,
+    #[prost(bool, tag = "2")]
+    advisor_proposed: bool,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacyStoredNetworkPolicyRule {
+    #[prost(string, tag = "1")]
+    name: String,
+    #[prost(message, repeated, tag = "2")]
+    endpoints: Vec<NetworkEndpoint>,
+    #[prost(message, repeated, tag = "3")]
+    binaries: Vec<LegacyStoredNetworkBinary>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacyStoredSandboxPolicy {
+    #[prost(map = "string, message", tag = "5")]
+    network_policies: HashMap<String, LegacyStoredNetworkPolicyRule>,
+}
+
+fn decode_stored_policy(payload: &[u8]) -> Result<ProtoSandboxPolicy, prost::DecodeError> {
+    let mut policy = ProtoSandboxPolicy::decode(payload)?;
+    let legacy = LegacyStoredSandboxPolicy::decode(payload)?;
+
+    for (rule_key, legacy_rule) in legacy.network_policies {
+        let advisor_paths = legacy_rule
+            .binaries
+            .into_iter()
+            .filter(|binary| binary.advisor_proposed)
+            .map(|binary| binary.path)
+            .collect::<HashSet<_>>();
+        if advisor_paths.is_empty() {
+            continue;
+        }
+
+        let Some(mut explicit_rule) = policy.network_policies.remove(&rule_key) else {
+            continue;
+        };
+        let mut advisor_rule = explicit_rule.clone();
+        advisor_rule
+            .binaries
+            .retain(|binary| advisor_paths.contains(&binary.path));
+        explicit_rule
+            .binaries
+            .retain(|binary| !advisor_paths.contains(&binary.path));
+        if advisor_rule.binaries.is_empty() {
+            policy.network_policies.insert(rule_key, explicit_rule);
+            continue;
+        }
+        for endpoint in &mut advisor_rule.endpoints {
+            endpoint.advisor_proposed = true;
+        }
+
+        if explicit_rule.binaries.is_empty() {
+            policy.network_policies.insert(rule_key, advisor_rule);
+            continue;
+        }
+
+        policy
+            .network_policies
+            .insert(rule_key.clone(), explicit_rule);
+        let key_base = format!("{rule_key}__legacy_advisor");
+        let mut advisor_key = key_base.clone();
+        let mut suffix = 2_u32;
+        while policy.network_policies.contains_key(&advisor_key) {
+            advisor_key = format!("{key_base}_{suffix}");
+            suffix += 1;
+        }
+        advisor_rule.name.clone_from(&advisor_key);
+        policy.network_policies.insert(advisor_key, advisor_rule);
+    }
+
+    Ok(policy)
+}
+
 fn emit_sandbox_policy_update_success() {
     openshell_core::telemetry::emit_lifecycle(
         LifecycleResource::SandboxPolicy,
@@ -627,6 +710,24 @@ fn compute_failed_proposal_evaluation_hash(
     hex::encode(hasher.finalize())
 }
 
+fn available_proposal_rule_name(
+    base_policy: &ProtoSandboxPolicy,
+    current_effective_policy: &ProtoSandboxPolicy,
+    requested_rule_name: &str,
+) -> String {
+    let mut candidate = requested_rule_name.to_string();
+    let mut suffix = 2_u32;
+    while base_policy.network_policies.contains_key(&candidate)
+        || current_effective_policy
+            .network_policies
+            .contains_key(&candidate)
+    {
+        candidate = format!("{requested_rule_name}_{suffix}");
+        suffix += 1;
+    }
+    candidate
+}
+
 #[allow(clippy::too_many_arguments)]
 fn evaluate_proposal_candidate(
     base_policy: &ProtoSandboxPolicy,
@@ -638,15 +739,30 @@ fn evaluate_proposal_candidate(
     validation_context: PolicyMergeValidationContext<'_>,
     reuse_validation_result: Option<&str>,
 ) -> ProposalEvaluation {
+    // The gateway owns advisor provenance. Do not rely on a supervisor or an
+    // agent-authored proposal to set this internal marker correctly: every
+    // proposed endpoint must remain ineligible for exact-host private-address
+    // trust until an explicit declaration or allowed_ips grants that trust.
+    let mut proposed_rule = proposed_rule.clone();
+    for endpoint in &mut proposed_rule.endpoints {
+        endpoint.advisor_proposed = true;
+    }
+
     let canonical = if analysis_mode == "mechanistic" {
         canonicalize_advisor_add_rule(
             base_policy,
             current_effective_policy,
             requested_rule_name,
-            proposed_rule,
+            &proposed_rule,
         )
     } else {
-        Ok((requested_rule_name.to_string(), proposed_rule.clone()))
+        let rule_name = available_proposal_rule_name(
+            base_policy,
+            current_effective_policy,
+            requested_rule_name,
+        );
+        proposed_rule.name.clone_from(&rule_name);
+        Ok((rule_name, proposed_rule.clone()))
     };
     let (rule_name, rule) = match canonical {
         Ok(value) => value,
@@ -660,7 +776,7 @@ fn evaluate_proposal_candidate(
                 validation_result: String::new(),
                 review_token: compute_failed_proposal_evaluation_hash(
                     requested_rule_name,
-                    proposed_rule,
+                    &proposed_rule,
                     current_effective_policy,
                     &application_error,
                 ),
@@ -5874,7 +5990,7 @@ fn deterministic_policy_hash(policy: &ProtoSandboxPolicy) -> String {
 fn canonical_policy_record_identity(
     record: &PolicyRecord,
 ) -> Result<(ProtoSandboxPolicy, String), Status> {
-    let decoded = ProtoSandboxPolicy::decode(record.policy_payload.as_slice())
+    let decoded = decode_stored_policy(record.policy_payload.as_slice())
         .map_err(|error| Status::internal(format!("decode policy revision failed: {error}")))?;
     let policy = validate_and_canonicalize_stored_policy(decoded, STORED_POLICY_SOURCE_HISTORY)?;
     let hash = deterministic_policy_hash(&policy);
@@ -7038,7 +7154,7 @@ fn decode_policy_from_global_settings(
 
     let raw = hex::decode(encoded)
         .map_err(|e| Status::internal(format!("global policy decode failed: {e}")))?;
-    let policy = ProtoSandboxPolicy::decode(raw.as_slice())
+    let policy = decode_stored_policy(raw.as_slice())
         .map_err(|e| Status::internal(format!("global policy protobuf decode failed: {e}")))?;
     validate_and_canonicalize_stored_policy(policy, STORED_POLICY_SOURCE_GLOBAL).map(Some)
 }
@@ -7159,6 +7275,120 @@ mod tests {
                 },
             }));
         request
+    }
+
+    #[test]
+    fn stored_policy_decode_splits_legacy_advisor_binary_provenance() {
+        #[derive(Clone, PartialEq, Message)]
+        struct LegacyStoredPolicyRevisionPayload {
+            #[prost(message, optional, tag = "1")]
+            policy: Option<LegacyStoredSandboxPolicy>,
+        }
+
+        let legacy = LegacyStoredSandboxPolicy {
+            network_policies: HashMap::from([(
+                "cargo_registry".to_string(),
+                LegacyStoredNetworkPolicyRule {
+                    name: "cargo-registry".to_string(),
+                    endpoints: vec![NetworkEndpoint {
+                        host: "index.crates.io".to_string(),
+                        port: 443,
+                        ..Default::default()
+                    }],
+                    binaries: vec![
+                        LegacyStoredNetworkBinary {
+                            path: "/usr/bin/cargo".to_string(),
+                            advisor_proposed: false,
+                        },
+                        LegacyStoredNetworkBinary {
+                            path: "/usr/bin/curl".to_string(),
+                            advisor_proposed: true,
+                        },
+                    ],
+                },
+            )]),
+        };
+
+        let wrapped = LegacyStoredPolicyRevisionPayload {
+            policy: Some(legacy),
+        }
+        .encode_to_vec();
+        let record = crate::policy_store::policy_record_from_parts(
+            "revision-1".to_string(),
+            "sandbox-1".to_string(),
+            1,
+            "loaded".to_string(),
+            &wrapped,
+            1,
+        )
+        .unwrap();
+        let decoded = decode_stored_policy(&record.policy_payload).unwrap();
+        let explicit = &decoded.network_policies["cargo_registry"];
+        assert_eq!(explicit.binaries[0].path, "/usr/bin/cargo");
+        assert!(!explicit.endpoints[0].advisor_proposed);
+
+        let advisor = &decoded.network_policies["cargo_registry__legacy_advisor"];
+        assert_eq!(advisor.binaries[0].path, "/usr/bin/curl");
+        assert!(advisor.endpoints[0].advisor_proposed);
+
+        let round_tripped = decode_stored_policy(&decoded.encode_to_vec()).unwrap();
+        assert_eq!(round_tripped, decoded);
+    }
+
+    #[test]
+    fn agent_authored_candidate_avoids_explicit_rule_name_collision() {
+        let mut base = ProtoSandboxPolicy::default();
+        base.network_policies.insert(
+            "allow_index_crates_io_443".to_string(),
+            NetworkPolicyRule {
+                name: "explicit-index".to_string(),
+                endpoints: vec![NetworkEndpoint {
+                    host: "index.crates.io".to_string(),
+                    port: 443,
+                    ..Default::default()
+                }],
+                binaries: vec![NetworkBinary {
+                    path: "/usr/bin/cargo".to_string(),
+                }],
+            },
+        );
+        let proposal = NetworkPolicyRule {
+            name: "allow_index_crates_io_443".to_string(),
+            endpoints: vec![NetworkEndpoint {
+                host: "index.crates.io".to_string(),
+                port: 443,
+                ..Default::default()
+            }],
+            binaries: vec![NetworkBinary {
+                path: "/usr/bin/curl".to_string(),
+            }],
+        };
+
+        let evaluation = evaluate_proposal_candidate(
+            &base,
+            &base,
+            "allow_index_crates_io_443",
+            &proposal,
+            "agent_authored",
+            &CredentialSet::default(),
+            PolicyMergeValidationContext {
+                provider_layers: &[],
+                credential_binding: None,
+            },
+            None,
+        );
+
+        assert!(evaluation.application_error.is_empty());
+        assert_eq!(evaluation.rule_name, "allow_index_crates_io_443_2");
+        assert!(evaluation.rule.endpoints[0].advisor_proposed);
+        let candidate = evaluation.candidate_effective_policy.unwrap();
+        assert_eq!(
+            candidate.network_policies["allow_index_crates_io_443"].binaries[0].path,
+            "/usr/bin/cargo"
+        );
+        assert!(
+            candidate.network_policies["allow_index_crates_io_443_2"].endpoints[0].advisor_proposed
+        );
     }
 
     /// Wrap a request with a sandbox `Principal` bound to `sandbox_id`.
@@ -9601,7 +9831,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -9724,7 +9953,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn provider_policy_layers_include_custom_provider_profiles() {
         let store = test_store().await;
         store
@@ -9769,7 +9997,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/custom".to_string(),
-                        harness: true,
                     }],
                     inference_capable: false,
                     discovery: None,
@@ -9793,7 +10020,7 @@ mod tests {
         assert_eq!(layers[0].rule.endpoints[0].allowed_ips, vec!["10.0.0.0/24"]);
         assert!(layers[0].rule.endpoints[0].allow_encoded_slash);
         assert_eq!(layers[0].rule.endpoints[0].path, "/v1");
-        assert!(layers[0].rule.binaries[0].harness);
+        assert_eq!(layers[0].rule.binaries[0].path, "/usr/bin/custom");
     }
 
     #[tokio::test]
@@ -12309,7 +12536,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn custom_imported_profile_policy_and_env_follow_attach_detach_lifecycle() {
         use crate::grpc::provider::handle_import_provider_profiles;
         use crate::grpc::sandbox::{
@@ -12358,7 +12584,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/custom".to_string(),
-                            harness: true,
                         }],
                         inference_capable: false,
                         discovery: None,
@@ -12725,7 +12950,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: binary.to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -12747,6 +12971,11 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
+            let proposed_rule = NetworkPolicyRule::decode(chunk.proposed_rule.as_slice()).unwrap();
+            assert!(
+                proposed_rule.endpoints[0].advisor_proposed,
+                "the gateway must stamp advisor endpoint provenance"
+            );
             chunk.validation_result = format!("prover: cached sentinel {index}");
             assert!(
                 state
@@ -12791,6 +13020,12 @@ mod tests {
         let policy = ProtoSandboxPolicy::decode(revision.policy_payload.as_slice()).unwrap();
         assert!(policy.network_policies.contains_key("alpha"));
         assert!(policy.network_policies.contains_key("beta"));
+        assert!(
+            policy
+                .network_policies
+                .values()
+                .all(|rule| rule.endpoints[0].advisor_proposed)
+        );
         for (index, chunk) in chunks.iter().enumerate() {
             let stored = state
                 .store
@@ -12842,7 +13077,6 @@ mod tests {
                             }],
                             binaries: vec![NetworkBinary {
                                 path: "/usr/bin/curl".to_string(),
-                                ..Default::default()
                             }],
                         }),
                         ..Default::default()
@@ -12862,7 +13096,6 @@ mod tests {
                             }],
                             binaries: vec![NetworkBinary {
                                 path: "/usr/bin/wget".to_string(),
-                                ..Default::default()
                             }],
                         }),
                         ..Default::default()
@@ -12984,7 +13217,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".to_string(),
-                        ..Default::default()
                     }],
                 },
             },
@@ -12999,7 +13231,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/wget".to_string(),
-                        ..Default::default()
                     }],
                 },
             },
@@ -13066,7 +13297,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -13176,7 +13406,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let submit = handle_submit_policy_analysis(
@@ -13294,7 +13523,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let mut chunk = pending_draft_chunk("legacy-private", sandbox_id);
@@ -13369,7 +13597,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -13434,7 +13661,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let first = handle_submit_policy_analysis(
@@ -13601,7 +13827,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -13854,7 +14079,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -13979,7 +14203,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -14091,7 +14314,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let mechanistic_submit = handle_submit_policy_analysis(
@@ -14171,7 +14393,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let agent_submit = handle_submit_policy_analysis(
@@ -14304,7 +14525,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -14373,7 +14593,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/cargo".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -14398,14 +14617,9 @@ mod tests {
         state.store.put_message(&sandbox).await.unwrap();
         seed_sandbox_approval_mode(&state, &sandbox_name, "auto").await;
 
-        let mut advisor_binary = NetworkBinary {
+        let advisor_binary = NetworkBinary {
             path: "/usr/bin/curl".to_string(),
-            ..Default::default()
         };
-        #[allow(deprecated)]
-        {
-            advisor_binary.harness = true;
-        }
         handle_submit_policy_analysis(
             &state,
             with_user(Request::new(SubmitPolicyAnalysisRequest {
@@ -14542,7 +14756,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -14616,7 +14829,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".to_string(),
-                            ..Default::default()
                         }],
                     }),
                     ..Default::default()
@@ -14671,7 +14883,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/wget".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -14750,7 +14961,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let submit = handle_submit_policy_analysis(
@@ -14854,7 +15064,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -14960,7 +15169,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15059,7 +15267,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15149,7 +15356,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15243,7 +15449,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15340,7 +15545,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15433,7 +15637,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15498,7 +15701,6 @@ mod tests {
                 endpoints: vec![endpoint],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             }),
             ..Default::default()
@@ -15581,7 +15783,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let chunk = DraftChunkRecord {
@@ -15704,7 +15905,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15806,7 +16006,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15897,7 +16096,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -15991,7 +16189,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".to_string(),
-                        ..Default::default()
                     }],
                     inference_capable: false,
                     discovery: None,
@@ -16032,7 +16229,6 @@ mod tests {
         sandbox.set_phase(SandboxPhase::Ready as i32);
         state.store.put_message(&sandbox).await.unwrap();
 
-        #[allow(deprecated)]
         let proposed_rule = NetworkPolicyRule {
             name: "github_contents_write".to_string(),
             endpoints: vec![NetworkEndpoint {
@@ -16055,7 +16251,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                harness: true,
             }],
         };
 
@@ -16239,7 +16434,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let step1 = handle_submit_policy_analysis(
@@ -16280,7 +16474,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let step2 = handle_submit_policy_analysis(
@@ -16417,7 +16610,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -16534,7 +16726,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let submit_one = || {
@@ -16654,7 +16845,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let submit_one = || {
@@ -16922,7 +17112,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -17080,7 +17269,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
 
@@ -17299,7 +17487,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         };
@@ -17327,7 +17514,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/node".to_string(),
-                    ..Default::default()
                 }],
             },
         };
@@ -17355,7 +17541,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/node".to_string(),
-                    ..Default::default()
                 }],
             },
         };
@@ -17382,7 +17567,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let chunk = DraftChunkRecord {
@@ -17452,7 +17636,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".to_string(),
-                        ..Default::default()
                     }],
                 },
             ))
@@ -17481,7 +17664,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let chunk = DraftChunkRecord {
@@ -17555,7 +17737,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".to_string(),
-                        ..Default::default()
                     }],
                 },
             ))
@@ -17584,7 +17765,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         };
         let chunk = DraftChunkRecord {
@@ -18541,7 +18721,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             }
         }

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -7278,17 +7278,43 @@ mod tests {
     }
 
     #[test]
-    fn stored_policy_decode_splits_legacy_advisor_binary_provenance() {
+    fn stored_policy_decode_migrates_legacy_provenance_and_preserves_unknown_fields() {
+        #[derive(Clone, PartialEq, Message)]
+        struct FutureStoredNetworkBinary {
+            #[prost(string, tag = "1")]
+            path: String,
+            #[prost(bool, tag = "2")]
+            advisor_proposed: bool,
+            #[prost(string, tag = "99")]
+            future_metadata: String,
+        }
+
+        #[derive(Clone, PartialEq, Message)]
+        struct FutureStoredNetworkPolicyRule {
+            #[prost(string, tag = "1")]
+            name: String,
+            #[prost(message, repeated, tag = "2")]
+            endpoints: Vec<NetworkEndpoint>,
+            #[prost(message, repeated, tag = "3")]
+            binaries: Vec<FutureStoredNetworkBinary>,
+        }
+
+        #[derive(Clone, PartialEq, Message)]
+        struct FutureStoredSandboxPolicy {
+            #[prost(map = "string, message", tag = "5")]
+            network_policies: HashMap<String, FutureStoredNetworkPolicyRule>,
+        }
+
         #[derive(Clone, PartialEq, Message)]
         struct LegacyStoredPolicyRevisionPayload {
             #[prost(message, optional, tag = "1")]
-            policy: Option<LegacyStoredSandboxPolicy>,
+            policy: Option<FutureStoredSandboxPolicy>,
         }
 
-        let legacy = LegacyStoredSandboxPolicy {
+        let legacy = FutureStoredSandboxPolicy {
             network_policies: HashMap::from([(
                 "cargo_registry".to_string(),
-                LegacyStoredNetworkPolicyRule {
+                FutureStoredNetworkPolicyRule {
                     name: "cargo-registry".to_string(),
                     endpoints: vec![NetworkEndpoint {
                         host: "index.crates.io".to_string(),
@@ -7296,13 +7322,15 @@ mod tests {
                         ..Default::default()
                     }],
                     binaries: vec![
-                        LegacyStoredNetworkBinary {
+                        FutureStoredNetworkBinary {
                             path: "/usr/bin/cargo".to_string(),
                             advisor_proposed: false,
+                            future_metadata: "keep-explicit".to_string(),
                         },
-                        LegacyStoredNetworkBinary {
+                        FutureStoredNetworkBinary {
                             path: "/usr/bin/curl".to_string(),
                             advisor_proposed: true,
+                            future_metadata: "keep-advisor".to_string(),
                         },
                     ],
                 },
@@ -7319,6 +7347,24 @@ mod tests {
             1,
             "loaded".to_string(),
             &wrapped,
+            1,
+        )
+        .unwrap();
+        let rewrapped = crate::policy_store::policy_payload_from_record(&record).unwrap();
+        let future_payload = LegacyStoredPolicyRevisionPayload::decode(rewrapped.as_slice())
+            .expect("rewrapped policy should retain unknown nested fields");
+        let future_rule = &future_payload.policy.unwrap().network_policies["cargo_registry"];
+        assert!(!future_rule.binaries[0].advisor_proposed);
+        assert_eq!(future_rule.binaries[0].future_metadata, "keep-explicit");
+        assert!(future_rule.binaries[1].advisor_proposed);
+        assert_eq!(future_rule.binaries[1].future_metadata, "keep-advisor");
+
+        let record = crate::policy_store::policy_record_from_parts(
+            "revision-2".to_string(),
+            "sandbox-1".to_string(),
+            1,
+            "loaded".to_string(),
+            &rewrapped,
             1,
         )
         .unwrap();

--- a/crates/openshell-server/src/grpc/provider.rs
+++ b/crates/openshell-server/src/grpc/provider.rs
@@ -6381,7 +6381,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn import_provider_profiles_preserves_advanced_proto_policy_fields() {
         let state = test_server_state().await;
         let response = handle_import_provider_profiles(
@@ -6414,7 +6413,6 @@ mod tests {
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/advanced".to_string(),
-                            harness: true,
                         }],
                         inference_capable: false,
                         discovery: None,
@@ -6457,7 +6455,7 @@ mod tests {
         );
         assert!(endpoint.allow_encoded_slash);
         assert_eq!(endpoint.path, "/v1");
-        assert!(fetched.binaries[0].harness);
+        assert_eq!(fetched.binaries[0].path, "/usr/bin/advanced");
     }
 
     #[tokio::test]

--- a/crates/openshell-server/src/policy_store.rs
+++ b/crates/openshell-server/src/policy_store.rs
@@ -9,6 +9,20 @@ use openshell_core::proto::{NetworkPolicyRule, Sandbox, SandboxPolicy as ProtoSa
 use prost::Message;
 use std::collections::HashMap;
 
+#[derive(Clone, PartialEq, Message)]
+struct RawPolicyRevisionPayload {
+    #[prost(bytes = "vec", optional, tag = "1")]
+    policy: Option<Vec<u8>>,
+    #[prost(string, tag = "2")]
+    hash: String,
+    #[prost(string, tag = "3")]
+    load_error: String,
+    #[prost(int64, tag = "4")]
+    loaded_at_ms: i64,
+    #[prost(map = "string, string", tag = "5")]
+    provenance: HashMap<String, String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct AtomicPolicyRevisionWrite {
     pub id: String,
@@ -448,10 +462,10 @@ impl PolicyStoreExt for Store {
 }
 
 pub fn policy_payload_from_record(record: &PolicyRecord) -> PersistenceResult<Vec<u8>> {
-    let policy = ProtoSandboxPolicy::decode(record.policy_payload.as_slice())
+    ProtoSandboxPolicy::decode(record.policy_payload.as_slice())
         .map_err(|e| PersistenceError::Decode(format!("decode policy payload failed: {e}")))?;
-    Ok(PolicyRevisionPayload {
-        policy: Some(policy),
+    Ok(RawPolicyRevisionPayload {
+        policy: Some(record.policy_payload.clone()),
         hash: record.policy_hash.clone(),
         load_error: record.load_error.clone().unwrap_or_default(),
         loaded_at_ms: record.loaded_at_ms.unwrap_or(0),
@@ -468,16 +482,21 @@ pub fn policy_record_from_parts(
     payload: &[u8],
     created_at_ms: i64,
 ) -> PersistenceResult<PolicyRecord> {
+    let raw_wrapper = RawPolicyRevisionPayload::decode(payload)
+        .map_err(|e| PersistenceError::Decode(format!("decode raw policy wrapper failed: {e}")))?;
     let wrapper = PolicyRevisionPayload::decode(payload)
         .map_err(|e| PersistenceError::Decode(format!("decode policy wrapper failed: {e}")))?;
-    let policy = wrapper
+    wrapper
+        .policy
+        .ok_or_else(|| PersistenceError::Decode("policy wrapper missing policy".to_string()))?;
+    let policy_payload = raw_wrapper
         .policy
         .ok_or_else(|| PersistenceError::Decode("policy wrapper missing policy".to_string()))?;
     Ok(PolicyRecord {
         id,
         sandbox_id,
         version,
-        policy_payload: policy.encode_to_vec(),
+        policy_payload,
         policy_hash: wrapper.hash,
         status,
         load_error: if wrapper.load_error.is_empty() {

--- a/crates/openshell-server/src/storage_proto.rs
+++ b/crates/openshell-server/src/storage_proto.rs
@@ -119,9 +119,9 @@ mod tests {
     const STORAGE_V1_SCHEMA_SHA256: &str =
         "79c72615d957fc0653c672f61998bf7d8d21b757bc05d07b3fff92bd70fc8f52";
     const PUBLIC_RPC_SCHEMA_SHA256: &str =
-        "0f14943574349d02bdc61076c8c5a59a98b627325564ef1a6d21d7941825dc46";
+        "8ac68c71d93e6a5e56406b8df1882ee40c6066270969e03eb99803f0e6396fc1";
     const DURABLE_SCHEMA_SHA256: &str =
-        "920a5243dfb37ce709f0f562a47d17791a5ede90fd7f662ed01542abd60a0dfb";
+        "369b36511c2e38b9df9621704a00123516c7538d8ee89a499158d7de5cee1882";
     const PUBLIC_DURABLE_OVERLAP_SHA256: &str =
         "05add438ba041defc98d791038ae593d3f09352677cae43f2276d494205ce415";
     // Synthetic payloads generated with the public declarations at v0.0.116,

--- a/crates/openshell-supervisor-network/data/sandbox-policy.rego
+++ b/crates/openshell-supervisor-network/data/sandbox-policy.rego
@@ -171,36 +171,6 @@ binary_allowed(policy, exec) if {
 	glob.match(b.path, ["/"], p)
 }
 
-user_declared_binary_allowed(_, _) if {
-	not binary_identity_required
-}
-
-user_declared_binary_allowed(policy, exec) if {
-	some b
-	b := policy.binaries[_]
-	not object.get(b, "advisor_proposed", false)
-	not contains(b.path, "*")
-	b.path == exec.path
-}
-
-user_declared_binary_allowed(policy, exec) if {
-	some b
-	b := policy.binaries[_]
-	not object.get(b, "advisor_proposed", false)
-	not contains(b.path, "*")
-	ancestor := exec.ancestors[_]
-	b.path == ancestor
-}
-
-user_declared_binary_allowed(policy, exec) if {
-	some b in policy.binaries
-	not object.get(b, "advisor_proposed", false)
-	contains(b.path, "*")
-	all_paths := array.concat([exec.path], exec.ancestors)
-	some p in all_paths
-	glob.match(b.path, ["/"], p)
-}
-
 # --- Network action (allow / deny) ---
 #
 # These rules are mutually exclusive by construction:
@@ -982,7 +952,7 @@ _policy_has_exact_declared_endpoint(policy) if {
 exact_declared_endpoint_host if {
 	some pname
 	policy := data.network_policies[pname]
-	user_declared_binary_allowed(policy, input.exec)
+	binary_allowed(policy, input.exec)
 	_policy_has_exact_declared_endpoint(policy)
 }
 

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -5220,7 +5220,6 @@ network_policies:
                         }],
                         binaries: vec![NetworkBinary {
                             path: "/usr/bin/curl".into(),
-                            ..Default::default()
                         }],
                     },
                 );

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -2387,7 +2387,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -2188,17 +2188,7 @@ fn proto_to_opa_data_json(proto: &ProtoSandboxPolicy, entrypoint_pid: u32) -> St
                 .binaries
                 .iter()
                 .flat_map(|b| {
-                    // The deprecated harness bit is ignored by policy YAML, but
-                    // advisor-generated proposals use it as internal provenance.
-                    #[allow(deprecated)]
-                    let advisor_proposed = b.harness;
-                    let binary_entry = |path: &str| {
-                        let mut entry = serde_json::json!({"path": path});
-                        if advisor_proposed {
-                            entry["advisor_proposed"] = true.into();
-                        }
-                        entry
-                    };
+                    let binary_entry = |path: &str| serde_json::json!({"path": path});
                     let mut entries = vec![binary_entry(&b.path)];
                     match resolve_binary_in_container(&b.path, entrypoint_pid) {
                         BinaryResolution::Resolved(resolved) => {
@@ -2340,7 +2330,6 @@ mod tests {
                 ],
                 binaries: vec![NetworkBinary {
                     path: "/usr/local/bin/claude".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -2355,7 +2344,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/glab".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -3452,7 +3440,6 @@ process:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -3990,7 +3977,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4062,7 +4048,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -4139,7 +4124,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5513,7 +5497,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/node".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5571,7 +5554,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/node".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5630,7 +5612,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/local/bin/claude".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5691,7 +5672,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/local/bin/aws".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5751,7 +5731,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/node".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5882,7 +5861,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -5897,7 +5875,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/bash".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -7131,64 +7108,6 @@ network_policies:
     }
 
     #[test]
-    fn exact_declared_endpoint_host_false_for_advisor_proposed_binary() {
-        let mut network_policies = std::collections::HashMap::new();
-        let mut proposal_binary = NetworkBinary {
-            path: "/usr/bin/curl".to_string(),
-            ..Default::default()
-        };
-        #[allow(deprecated)]
-        {
-            proposal_binary.harness = true;
-        }
-        network_policies.insert(
-            "allow_mcp_internal_corp_example_com_8443".to_string(),
-            NetworkPolicyRule {
-                name: "allow_mcp_internal_corp_example_com_8443".to_string(),
-                endpoints: vec![NetworkEndpoint {
-                    host: "mcp-internal.corp.example.com".to_string(),
-                    port: 8443,
-                    ..Default::default()
-                }],
-                binaries: vec![proposal_binary],
-            },
-        );
-        let proto = ProtoSandboxPolicy {
-            version: 1,
-            filesystem: Some(ProtoFs {
-                include_workdir: true,
-                read_only: vec![],
-                read_write: vec![],
-            }),
-            landlock: Some(openshell_core::proto::LandlockPolicy {
-                compatibility: "best_effort".to_string(),
-            }),
-            process: Some(ProtoProc {
-                run_as_user: "sandbox".to_string(),
-                run_as_group: "sandbox".to_string(),
-            }),
-            network_policies,
-            network_middlewares: std::collections::HashMap::default(),
-        };
-        let engine = OpaEngine::from_proto(&proto).expect("engine from proto");
-        let input = NetworkInput {
-            host: "mcp-internal.corp.example.com".into(),
-            port: 8443,
-            binary_path: PathBuf::from("/usr/bin/curl"),
-            binary_sha256: "unused".into(),
-            ancestors: vec![],
-            cmdline_paths: vec![],
-        };
-
-        let decision = engine.evaluate_network(&input).unwrap();
-        assert!(
-            decision.allowed,
-            "advisor proposal should still allow at OPA L4"
-        );
-        assert!(!engine.query_exact_declared_endpoint_host(&input).unwrap());
-    }
-
-    #[test]
     fn exact_declared_endpoint_host_false_for_advisor_proposed_endpoint() {
         let mut network_policies = std::collections::HashMap::new();
         network_policies.insert(
@@ -7204,7 +7123,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/python".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -7275,7 +7193,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -7506,7 +7423,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -8483,7 +8399,6 @@ network_policies:
                     .iter()
                     .map(|p| NetworkBinary {
                         path: p.to_str().unwrap().to_string(),
-                        ..Default::default()
                     })
                     .collect(),
             },
@@ -8543,7 +8458,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/python3".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -8617,7 +8531,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/python3".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -8824,7 +8737,6 @@ network_policies:
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/python3".to_string(),
-                    ..Default::default()
                 }],
             },
         );
@@ -9115,10 +9027,7 @@ network_policies:
                     port: 443,
                     ..Default::default()
                 }],
-                binaries: vec![NetworkBinary {
-                    path: link_path,
-                    ..Default::default()
-                }],
+                binaries: vec![NetworkBinary { path: link_path }],
             },
         );
         let proto = ProtoSandboxPolicy {
@@ -9193,10 +9102,7 @@ network_policies:
                     port: 443,
                     ..Default::default()
                 }],
-                binaries: vec![NetworkBinary {
-                    path: link_path,
-                    ..Default::default()
-                }],
+                binaries: vec![NetworkBinary { path: link_path }],
             },
         );
         let proto = ProtoSandboxPolicy {

--- a/crates/openshell-supervisor-network/src/policy_local.rs
+++ b/crates/openshell-supervisor-network/src/policy_local.rs
@@ -1110,19 +1110,7 @@ fn network_rule_from_json(
     let binaries = rule
         .binaries
         .into_iter()
-        .map(|binary| {
-            let mut proposal_binary = NetworkBinary {
-                path: binary.path,
-                ..Default::default()
-            };
-            // The deprecated harness bit is ignored by policy YAML, but OPA
-            // maps it to advisor_proposed to preserve the SSRF two-step flow.
-            #[allow(deprecated)]
-            {
-                proposal_binary.harness = true;
-            }
-            proposal_binary
-        })
+        .map(|binary| NetworkBinary { path: binary.path })
         .collect();
 
     Ok(NetworkPolicyRule {
@@ -1472,10 +1460,7 @@ mod tests {
         assert_eq!(rule.endpoints[0].ports, vec![443]);
         assert_eq!(rule.endpoints[0].protocol, "rest");
         assert!(rule.endpoints[0].advisor_proposed);
-        #[allow(deprecated)]
-        {
-            assert!(rule.binaries[0].harness);
-        }
+        assert_eq!(rule.binaries[0].path, "/usr/bin/gh");
         assert_eq!(
             rule.endpoints[0].rules[0].allow.as_ref().unwrap().path,
             "/user/repos"
@@ -2020,7 +2005,6 @@ mod tests {
                 }],
                 binaries: vec![NetworkBinary {
                     path: "/usr/bin/curl".to_string(),
-                    ..Default::default()
                 }],
             }),
             ..Default::default()
@@ -2044,7 +2028,6 @@ mod tests {
             }],
             binaries: vec![NetworkBinary {
                 path: "/usr/bin/curl".to_string(),
-                ..Default::default()
             }],
         }
     }
@@ -2119,7 +2102,6 @@ mod tests {
                     }],
                     binaries: vec![NetworkBinary {
                         path: "/usr/bin/curl".to_string(),
-                        ..Default::default()
                     }],
                 })));
             })

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -10,6 +10,14 @@ position: 6
 
 NVIDIA OpenShell follows a frequent release cadence. Use the following GitHub resources directly.
 
+## 0.1.0 migration notes
+
+### Network policy binaries
+
+OpenShell 0.1.0 removes the deprecated `NetworkBinary.harness` protobuf field and reserves its field number and name. Generated protobuf decoders ignore the unknown value. When the gateway loads policy history written by an older version, it migrates binaries marked by the former field into endpoint-provenance-marked rules so the upgrade cannot widen private-address access.
+
+Remove `harness` from sandbox policies and provider profiles before upgrading. Policy and profile YAML now reject the property. Provider profiles should list binaries as scalar paths, such as `- /usr/bin/curl`; the transitional object form `- path: /usr/bin/curl` remains accepted and is exported as a scalar.
+
 | Resource | Description |
 |---|---|
 | [Releases](https://github.com/NVIDIA/OpenShell/releases) | Versioned release notes and downloadable assets. |

--- a/docs/providers/profiles.mdx
+++ b/docs/providers/profiles.mdx
@@ -436,7 +436,7 @@ environment value under the actual environment variable key.
 
 `endpoints` contains the same endpoint object shape as sandbox network policy. A profile can use access presets, protocol-specific allow rules, deny rules, WebSocket credential rewriting, request body credential rewriting, GraphQL fields, and SSRF IP allowlists. Because profile credentials are not mapped to individual endpoints, OpenShell conservatively treats every endpoint in a profile that declares credentials as credentialed. Such endpoints require L7 inspection and cannot use `tls: skip` unless the profile explicitly sets `allow_uninspected_credentials: true`.
 
-`binaries` contains the executable paths allowed to reach the profile endpoints when the profile contributes policy to a sandbox.
+`binaries` contains the executable paths allowed to reach the profile endpoints when the profile contributes policy to a sandbox. Write each binary as a scalar path. OpenShell also accepts the transitional object form `- path: /usr/bin/example` and exports it as a scalar. The removed `harness` property is rejected; delete it from profiles created before 0.1.0.
 
 `inference_capable` is informational metadata that marks profiles intended for
 model and inference APIs. It does not grant access, select a model, configure a

--- a/proto/sandbox.proto
+++ b/proto/sandbox.proto
@@ -311,8 +311,8 @@ message L7QueryMatcher {
 // A binary identity for network policy matching.
 message NetworkBinary {
   string path = 1;
-  // Deprecated: the harness concept has been removed. This field is ignored.
-  bool harness = 2 [deprecated = true];
+  reserved 2;
+  reserved "harness";
 }
 
 // Request to get sandbox settings by sandbox ID.

--- a/sdk/go/proto/sandboxv1/sandbox.pb.go
+++ b/sdk/go/proto/sandboxv1/sandbox.pb.go
@@ -1439,12 +1439,8 @@ func (x *L7QueryMatcher) GetAny() []string {
 
 // A binary identity for network policy matching.
 type NetworkBinary struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	Path  string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	// Deprecated: the harness concept has been removed. This field is ignored.
-	//
-	// Deprecated: Marked as deprecated in sandbox.proto.
-	Harness       bool `protobuf:"varint,2,opt,name=harness,proto3" json:"harness,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1484,14 +1480,6 @@ func (x *NetworkBinary) GetPath() string {
 		return x.Path
 	}
 	return ""
-}
-
-// Deprecated: Marked as deprecated in sandbox.proto.
-func (x *NetworkBinary) GetHarness() bool {
-	if x != nil {
-		return x.Harness
-	}
-	return false
 }
 
 // Request to get sandbox settings by sandbox ID.
@@ -2196,10 +2184,9 @@ const file_sandbox_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2$.openshell.sandbox.v1.L7QueryMatcherR\x05value:\x028\x01J\x04\b\b\x10\t\"6\n" +
 	"\x0eL7QueryMatcher\x12\x12\n" +
 	"\x04glob\x18\x01 \x01(\tR\x04glob\x12\x10\n" +
-	"\x03any\x18\x02 \x03(\tR\x03any\"A\n" +
+	"\x03any\x18\x02 \x03(\tR\x03any\"2\n" +
 	"\rNetworkBinary\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1c\n" +
-	"\aharness\x18\x02 \x01(\bB\x02\x18\x01R\aharness\"8\n" +
+	"\x04path\x18\x01 \x01(\tR\x04pathJ\x04\b\x02\x10\x03R\aharness\"8\n" +
 	"\x17GetSandboxConfigRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\x19\n" +


### PR DESCRIPTION
## Summary

Remove the deprecated `NetworkBinary.harness` field before 0.1.0 while preserving advisor-origin provenance at the endpoint/rule boundary.

## Related Issue

Closes #3054

## Changes

- Reserve protobuf field number 2 and name `harness`, update generated Go bindings, and remove runtime, SDK, and profile uses.
- Reject legacy YAML/profile `harness` input with migration guidance while retaining protobuf wire compatibility.
- Move advisor provenance enforcement to gateway-stamped endpoints and keep advisor binaries separated from explicit rules, including rule-name collisions.
- Migrate legacy stored policy-history provenance without dropping unknown nested wire fields.
- Update policy architecture, provider profile docs, and 0.1.0 migration notes.

## Testing

- `mise run pre-commit`
- `cargo test --workspace --exclude openshell-server -q`
- `cargo test -p openshell-server --lib -q`
- `cargo test -p openshell-supervisor-network --lib -q`
- `cargo test -p openshell-sandbox --lib -q`
- `mise run go:ci`
- `mise run sdk:ts:ci`
- `mise run test:python`
- Focused policy/profile/protobuf migration and provenance regressions.
- `mise run e2e:docker` — blocked before execution because the local Docker daemon was unreachable.

## Checklist

- [x] Implementation is scoped to #3054.
- [x] Tests and pre-commit checks pass.
- [x] Documentation and migration guidance are updated.
- [x] Commit is signed off for DCO.
- [ ] Docker-backed E2E completed (local Docker daemon unavailable).
