### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Please contact [openshell-maintainers@ai-openshell.org](mailto:openshell-maintainers@ai-openshell.org) or the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io) to report violations of the Code of Conduct.


### PR DESCRIPTION
## Summary

Add the CNCF project Code of Conduct entrypoint and identify the OpenShell maintainers and CNCF Code of Conduct Committee as reporting contacts.

## Related Issue

No issue required: this is a small repository governance documentation addition based on the CNCF project template.

## Changes

- Add `CODE_OF_CONDUCT.md`
- Link to the CNCF Code of Conduct
- Direct reports to `openshell-maintainers@ai-openshell.org` or `conduct@cncf.io`

## Testing

- [x] `mise run markdown:lint` passes
- [x] `git diff --check` passes
- [ ] `mise run pre-commit` passes (not run for this Markdown-only change, at requester direction)
- [ ] Unit tests added/updated (not applicable; documentation only)
- [ ] E2E tests added/updated (not applicable; documentation only)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; no architecture change)
