### PR TITLE
chore(example): refresh content guard lockfile

### DIFF
--- a/examples/supervisor-middleware-content-guard/Cargo.lock
+++ b/examples/supervisor-middleware-content-guard/Cargo.lock
@@ -854,6 +854,8 @@ dependencies = [
  "prost-types",
  "protoc-bin-vendored",
  "rustix",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror",
@@ -1244,6 +1246,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences: what this PR does and why -->
The lock file for the supervisor-middleware-content-guard example that is checked in appears to be stale, as the rust linting seems to modify it.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->
No issue required: just a left over from a previous commit I believe (https://github.com/NVIDIA/OpenShell/commit/857af42a16bd47aba45a5968083c95e940cd714e#diff-c3cb46923fe08088f925b7f0da5691c6ec7b989ab0a41648697fcb634c09fb84?)

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
