### PR TITLE
fix(sdk/go): honor explicitly-set zero option values in oidc defaults

### DIFF
--- a/sdk/go/openshell/v1/oidc/credentials_auth.go
+++ b/sdk/go/openshell/v1/oidc/credentials_auth.go
@@ -71,7 +71,13 @@ func (a *clientCredentialsAuth) accessTokenForExchange() (string, error) {
 		return accessToken, nil
 	}
 
-	exchangeCtx, cancel := context.WithTimeout(context.Background(), a.cfg.timeout)
+	// A zero timeout means "no deadline"; only bound the exchange when a
+	// positive timeout was configured (mirrors Login and DeviceFlow).
+	exchangeCtx := context.Background()
+	cancel := context.CancelFunc(func() {})
+	if a.cfg.timeout > 0 {
+		exchangeCtx, cancel = context.WithTimeout(exchangeCtx, a.cfg.timeout)
+	}
 	defer cancel()
 	token, err := exchangeClientCredentials(exchangeCtx, a.cfg, true)
 	if err != nil {

--- a/sdk/go/openshell/v1/oidc/credentials_test.go
+++ b/sdk/go/openshell/v1/oidc/credentials_test.go
@@ -308,38 +308,82 @@ func TestClientCredentialsAuthLateFlightReusesCachedToken(t *testing.T) {
 	assert.Equal(t, "cached-token", accessToken)
 }
 
-// A zero timeout means "no deadline". The exchange context must not be born
-// expired, so the token exchange should still succeed.
-func TestClientCredentialsAuthZeroTimeoutHasNoDeadline(t *testing.T) {
-	resetDiscoveryCache()
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/openid-configuration" {
-			_ = json.NewEncoder(w).Encode(map[string]string{
-				"issuer":                 server.URL,
-				"authorization_endpoint": server.URL + "/authorize",
-				"token_endpoint":         server.URL + "/token",
-			})
-			return
-		}
-		_, _ = w.Write([]byte(tokenResponseJSON("token", "", 3600)))
-	}))
-	t.Cleanup(server.Close)
+// A non-positive timeout means "no deadline". The exchange context must not be
+// born expired, so the token exchange should still succeed.
+func TestClientCredentialsAuthNonPositiveTimeoutHasNoDeadline(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -1 * time.Second} {
+		t.Run(timeout.String(), func(t *testing.T) {
+			resetDiscoveryCache()
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/.well-known/openid-configuration" {
+					_ = json.NewEncoder(w).Encode(map[string]string{
+						"issuer":                 server.URL,
+						"authorization_endpoint": server.URL + "/authorize",
+						"token_endpoint":         server.URL + "/token",
+					})
+					return
+				}
+				_, _ = w.Write([]byte(tokenResponseJSON("token", "", 3600)))
+			}))
+			t.Cleanup(server.Close)
 
-	auth, err := NewClientCredentialsAuth(
-		WithIssuer(server.URL),
-		WithClientID("client"),
-		WithClientSecret("secret"),
-		WithTimeout(0), // explicitly no timeout
-	)
-	require.NoError(t, err)
+			auth, err := NewClientCredentialsAuth(
+				WithIssuer(server.URL),
+				WithClientID("client"),
+				WithClientSecret("secret"),
+				WithTimeout(timeout), // explicitly no timeout
+			)
+			require.NoError(t, err)
 
-	// The explicit zero timeout must be preserved (not replaced by the default).
-	require.Zero(t, auth.(*clientCredentialsAuth).cfg.timeout)
+			// The explicit timeout must be preserved (not replaced by the default).
+			require.Equal(t, timeout, auth.(*clientCredentialsAuth).cfg.timeout)
 
-	metadata, err := auth.GetRequestMetadata(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, "Bearer token", metadata["authorization"])
+			metadata, err := auth.GetRequestMetadata(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, "Bearer token", metadata["authorization"])
+		})
+	}
+}
+
+// The client credentials grant has no user and no ID token, so "openid" must
+// never be forced onto it the way the interactive flows force it.
+func TestClientCredentialsScopesAreNotNormalized(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []LoginOption
+		want []string
+	}{
+		{
+			name: "unset sends no scopes",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "explicit empty sends no scopes",
+			opts: []LoginOption{WithScopes()},
+			want: []string{},
+		},
+		{
+			name: "application scopes are sent verbatim",
+			opts: []LoginOption{WithScopes("sandbox:read", "sandbox:write")},
+			want: []string{"sandbox:read", "sandbox:write"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := append([]LoginOption{
+				WithIssuer("https://issuer.example.com"),
+				WithClientID("client"),
+				WithClientSecret("secret"),
+			}, tt.opts...)
+
+			cfg, err := resolveClientCredentialsConfig(opts...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.scopes)
+		})
+	}
 }
 
 func TestClientCredentialsAuthCancellationDoesNotPoisonSharedExchange(t *testing.T) {

--- a/sdk/go/openshell/v1/oidc/credentials_test.go
+++ b/sdk/go/openshell/v1/oidc/credentials_test.go
@@ -308,6 +308,40 @@ func TestClientCredentialsAuthLateFlightReusesCachedToken(t *testing.T) {
 	assert.Equal(t, "cached-token", accessToken)
 }
 
+// A zero timeout means "no deadline". The exchange context must not be born
+// expired, so the token exchange should still succeed.
+func TestClientCredentialsAuthZeroTimeoutHasNoDeadline(t *testing.T) {
+	resetDiscoveryCache()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+			})
+			return
+		}
+		_, _ = w.Write([]byte(tokenResponseJSON("token", "", 3600)))
+	}))
+	t.Cleanup(server.Close)
+
+	auth, err := NewClientCredentialsAuth(
+		WithIssuer(server.URL),
+		WithClientID("client"),
+		WithClientSecret("secret"),
+		WithTimeout(0), // explicitly no timeout
+	)
+	require.NoError(t, err)
+
+	// The explicit zero timeout must be preserved (not replaced by the default).
+	require.Zero(t, auth.(*clientCredentialsAuth).cfg.timeout)
+
+	metadata, err := auth.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token", metadata["authorization"])
+}
+
 func TestClientCredentialsAuthCancellationDoesNotPoisonSharedExchange(t *testing.T) {
 	resetDiscoveryCache()
 	var server *httptest.Server

--- a/sdk/go/openshell/v1/oidc/device.go
+++ b/sdk/go/openshell/v1/oidc/device.go
@@ -50,6 +50,9 @@ func DeviceLogin(ctx context.Context, opts ...LoginOption) (*oauth2.Token, error
 		opt(cfg)
 	}
 	cfg.applyDefaults()
+	// DeviceLogin authenticates a user, so the request must be an OIDC one even
+	// when the caller supplied its own scopes.
+	cfg.requireOpenIDScope()
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline && cfg.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, cfg.timeout)

--- a/sdk/go/openshell/v1/oidc/device_test.go
+++ b/sdk/go/openshell/v1/oidc/device_test.go
@@ -120,6 +120,84 @@ func TestDeviceLogin_Success(t *testing.T) {
 
 // TestDeviceLogin_MissingIssuer verifies that DeviceLogin returns
 // ErrOIDCConfig when the issuer is not provided.
+// DeviceLogin authenticates a user, so the device authorization request must
+// carry "openid" on the wire even when the caller supplied its own scopes.
+func TestDeviceLogin_AlwaysRequestsOpenIDScope(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []LoginOption
+		want string
+	}{
+		{
+			name: "unset scopes send the defaults",
+			opts: nil,
+			want: "openid profile email",
+		},
+		{
+			name: "explicit empty still sends openid",
+			opts: []LoginOption{WithScopes()},
+			want: "openid",
+		},
+		{
+			name: "application scopes gain openid",
+			opts: []LoginOption{WithScopes("sandbox:read")},
+			want: "openid sandbox:read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDiscoveryCache()
+
+			var requestedScope string
+			var scopeSeen atomic.Bool
+			mux := http.NewServeMux()
+			var srv *httptest.Server
+
+			mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                        srv.URL,
+					"authorization_endpoint":        srv.URL + "/authorize",
+					"token_endpoint":                srv.URL + "/token",
+					"device_authorization_endpoint": srv.URL + "/device",
+				})
+			})
+			mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				requestedScope = r.Form.Get("scope")
+				scopeSeen.Store(true)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"device_code":      "test-device-code",
+					"user_code":        "ABCD-1234",
+					"verification_uri": "https://example.com/activate",
+					"expires_in":       300,
+					"interval":         1,
+				})
+			})
+			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tokenResponseJSON("device-access-token", "", 3600)))
+			})
+
+			srv = httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			opts := append([]LoginOption{
+				WithIssuer(srv.URL),
+				WithClientID("device-client"),
+				WithDisplayFunc(func(_, _ string) {}),
+			}, tt.opts...)
+
+			_, err := DeviceLogin(ctx, opts...)
+			require.NoError(t, err)
+			require.True(t, scopeSeen.Load(), "device authorization endpoint was not called")
+			assert.Equal(t, tt.want, requestedScope)
+		})
+	}
+}
+
 func TestDeviceLogin_MissingIssuer(t *testing.T) {
 	resetDiscoveryCache()
 

--- a/sdk/go/openshell/v1/oidc/oidc.go
+++ b/sdk/go/openshell/v1/oidc/oidc.go
@@ -37,6 +37,9 @@ func Login(ctx context.Context, gatewayName string, opts ...LoginOption) (*oauth
 		opt(cfg)
 	}
 	cfg.applyDefaults()
+	// Login authenticates a user, so the request must be an OIDC one even when
+	// the caller supplied its own scopes.
+	cfg.requireOpenIDScope()
 
 	// Apply configured timeout if the caller's context has no deadline.
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline && cfg.timeout > 0 {

--- a/sdk/go/openshell/v1/oidc/oidc_test.go
+++ b/sdk/go/openshell/v1/oidc/oidc_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,6 +189,72 @@ func TestLogin_KeyboardFlow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diskTok)
 	assert.Equal(t, "login-access-token", diskTok.AccessToken)
+}
+
+// Login authenticates a user, so the authorization URL must carry "openid"
+// even when the caller supplied its own scopes. An explicitly-empty scope
+// list must never produce a bare "scope=" parameter.
+func TestLogin_AlwaysRequestsOpenIDScope(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []LoginOption
+		want string
+	}{
+		{
+			name: "unset scopes send the defaults",
+			opts: nil,
+			want: "openid profile email",
+		},
+		{
+			name: "explicit empty still sends openid",
+			opts: []LoginOption{WithScopes()},
+			want: "openid",
+		},
+		{
+			name: "application scopes gain openid",
+			opts: []LoginOption{WithScopes("sandbox:read")},
+			want: "openid sandbox:read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDiscoveryCache()
+
+			provider := setupMockProvider(t)
+			var prompt strings.Builder
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			opts := append([]LoginOption{
+				WithIssuer(provider.URL),
+				WithClientID("test-client"),
+				WithInMemory(),
+				WithKeyboardFlow(),
+				withInput(strings.NewReader("keyboard-auth-code\n")),
+				withOutput(&prompt),
+			}, tt.opts...)
+
+			_, err := Login(ctx, "", opts...)
+			require.NoError(t, err)
+
+			// The keyboard flow prints the authorization URL it would open.
+			authURL := extractAuthURL(t, prompt.String())
+			assert.Equal(t, tt.want, authURL.Query().Get("scope"))
+		})
+	}
+}
+
+// extractAuthURL pulls the authorization URL out of the keyboard-flow prompt.
+func extractAuthURL(t *testing.T, prompt string) *url.URL {
+	t.Helper()
+	start := strings.Index(prompt, "http")
+	require.GreaterOrEqual(t, start, 0, "no authorization URL in prompt: %q", prompt)
+	raw := strings.Fields(prompt[start:])[0]
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
 }
 
 // TestLogin_InMemorySkipsPersistence verifies that WithInMemory()

--- a/sdk/go/openshell/v1/oidc/options.go
+++ b/sdk/go/openshell/v1/oidc/options.go
@@ -11,9 +11,13 @@ import (
 	"github.com/NVIDIA/OpenShell/sdk/go/openshell/v1/gateway"
 )
 
+// scopeOpenID is the scope that turns an OAuth2 authorization request into
+// an OpenID Connect one. Interactive flows always request it.
+const scopeOpenID = "openid"
+
 // defaultScopes are the OIDC scopes requested when no custom scopes
 // are specified via [WithScopes].
-var defaultScopes = []string{"openid", "profile", "email"}
+var defaultScopes = []string{scopeOpenID, "profile", "email"}
 
 // defaultTimeout is the maximum duration for interactive login flows
 // (browser, keyboard, device code) when no custom timeout is set.
@@ -59,6 +63,27 @@ func (c *loginConfig) applyDefaults() {
 	if !c.timeoutSet {
 		c.timeout = defaultTimeout
 	}
+}
+
+// requireOpenIDScope normalizes the scopes for an interactive flow so the
+// request is always an OpenID Connect one. "openid" is placed first and any
+// caller-supplied duplicate is dropped; the remaining scopes keep their order.
+//
+// Interactive flows authenticate a user, and the gateway requires a "sub"
+// claim on the resulting token, so "openid" is not optional there. Callers
+// remain free to request application scopes such as "sandbox:read". The
+// client credentials grant has no user and is left untouched.
+//
+// This mirrors build_scopes in crates/openshell-cli/src/oidc_auth.rs.
+func (c *loginConfig) requireOpenIDScope() {
+	normalized := make([]string, 0, len(c.scopes)+1)
+	normalized = append(normalized, scopeOpenID)
+	for _, scope := range c.scopes {
+		if scope != scopeOpenID {
+			normalized = append(normalized, scope)
+		}
+	}
+	c.scopes = normalized
 }
 
 // LoginOption configures a login attempt. Use the With* functions to
@@ -107,6 +132,12 @@ func WithAudience(audience string) LoginOption {
 
 // WithScopes overrides the default scopes (openid, profile, email).
 // The provided scopes replace the defaults entirely.
+//
+// [Login] and [DeviceLogin] always request "openid" in addition to the
+// provided scopes, so WithScopes("sandbox:read") sends "openid sandbox:read".
+// [ClientCredentials] and [NewClientCredentialsAuth] send exactly what is
+// provided, since that grant has no user and no ID token; calling
+// WithScopes with no arguments there sends no scope parameter at all.
 func WithScopes(scopes ...string) LoginOption {
 	return func(c *loginConfig) {
 		c.scopes = make([]string, len(scopes))
@@ -123,8 +154,12 @@ func WithCallbackPort(port int) LoginOption {
 	}
 }
 
-// WithTimeout sets the maximum duration for interactive login flows.
+// WithTimeout sets the maximum duration for a login flow.
 // The default is 2 minutes.
+//
+// A non-positive duration (d <= 0) means "no deadline": the flow runs until
+// it completes or the caller's context is cancelled. A caller-supplied
+// context that already carries a deadline always takes precedence.
 func WithTimeout(d time.Duration) LoginOption {
 	return func(c *loginConfig) {
 		c.timeout = d
@@ -180,6 +215,13 @@ func withTokenDir(dir string) LoginOption {
 func withInput(r io.Reader) LoginOption {
 	return func(c *loginConfig) {
 		c.input = r
+	}
+}
+
+// withOutput overrides the output writer for keyboard flow testing.
+func withOutput(w io.Writer) LoginOption {
+	return func(c *loginConfig) {
+		c.output = w
 	}
 }
 

--- a/sdk/go/openshell/v1/oidc/options.go
+++ b/sdk/go/openshell/v1/oidc/options.go
@@ -33,6 +33,7 @@ type loginConfig struct {
 	scopesSet      bool
 	callbackPort   int
 	timeout        time.Duration
+	timeoutSet     bool
 	keyboardFlow   bool
 	inMemory       bool
 	displayFunc    func(verificationURL, userCode string)
@@ -48,12 +49,14 @@ type loginConfig struct {
 // applyDefaults fills in default values for fields that were not set
 // by any option function.
 func (c *loginConfig) applyDefaults() {
-	if len(c.scopes) == 0 {
+	// Check set-ness, not the zero value, so an explicitly-set empty scope
+	// list or zero timeout is honored instead of being replaced by defaults.
+	if !c.scopesSet {
 		// Deep copy to avoid callers mutating the package-level slice.
 		c.scopes = make([]string, len(defaultScopes))
 		copy(c.scopes, defaultScopes)
 	}
-	if c.timeout == 0 {
+	if !c.timeoutSet {
 		c.timeout = defaultTimeout
 	}
 }
@@ -125,6 +128,7 @@ func WithCallbackPort(port int) LoginOption {
 func WithTimeout(d time.Duration) LoginOption {
 	return func(c *loginConfig) {
 		c.timeout = d
+		c.timeoutSet = true
 	}
 }
 

--- a/sdk/go/openshell/v1/oidc/options_test.go
+++ b/sdk/go/openshell/v1/oidc/options_test.go
@@ -82,6 +82,26 @@ func TestWithTimeout(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, cfg.timeout)
 }
 
+func TestWithScopes_ExplicitEmptyNotOverridden(t *testing.T) {
+	var cfg loginConfig
+	WithScopes()(&cfg) // caller explicitly requests no scopes
+	cfg.applyDefaults()
+
+	// An explicitly-set empty scope list must be honored, not replaced by defaults.
+	assert.True(t, cfg.scopesSet)
+	assert.Empty(t, cfg.scopes)
+}
+
+func TestWithTimeout_ExplicitZeroNotOverridden(t *testing.T) {
+	var cfg loginConfig
+	WithTimeout(0)(&cfg) // caller explicitly requests no timeout
+	cfg.applyDefaults()
+
+	// An explicitly-set zero timeout must be honored, not replaced by the default.
+	assert.True(t, cfg.timeoutSet)
+	assert.Zero(t, cfg.timeout)
+}
+
 func TestWithKeyboardFlow(t *testing.T) {
 	var cfg loginConfig
 	WithKeyboardFlow()(&cfg)

--- a/sdk/go/openshell/v1/oidc/options_test.go
+++ b/sdk/go/openshell/v1/oidc/options_test.go
@@ -102,6 +102,67 @@ func TestWithTimeout_ExplicitZeroNotOverridden(t *testing.T) {
 	assert.Zero(t, cfg.timeout)
 }
 
+func TestWithTimeout_NegativeMeansNoDeadline(t *testing.T) {
+	var cfg loginConfig
+	WithTimeout(-1 * time.Second)(&cfg)
+	cfg.applyDefaults()
+
+	// Every flow gates on timeout > 0, so a negative duration means
+	// "no deadline" exactly as zero does. It is not replaced by the default.
+	assert.True(t, cfg.timeoutSet)
+	assert.Negative(t, cfg.timeout)
+}
+
+// Interactive flows authenticate a user, so the request must carry the
+// "openid" scope regardless of what the caller asked for. This mirrors
+// build_scopes in crates/openshell-cli/src/oidc_auth.rs.
+func TestRequireOpenIDScope(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []LoginOption
+		want []string
+	}{
+		{
+			name: "unset scopes keep the defaults",
+			opts: nil,
+			want: []string{"openid", "profile", "email"},
+		},
+		{
+			name: "explicit empty still requests openid",
+			opts: []LoginOption{WithScopes()},
+			want: []string{"openid"},
+		},
+		{
+			name: "application scopes gain openid",
+			opts: []LoginOption{WithScopes("sandbox:read", "sandbox:write")},
+			want: []string{"openid", "sandbox:read", "sandbox:write"},
+		},
+		{
+			name: "existing openid is not duplicated",
+			opts: []LoginOption{WithScopes("openid", "profile")},
+			want: []string{"openid", "profile"},
+		},
+		{
+			name: "openid is normalized to the front",
+			opts: []LoginOption{WithScopes("profile", "openid", "email")},
+			want: []string{"openid", "profile", "email"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg loginConfig
+			for _, opt := range tt.opts {
+				opt(&cfg)
+			}
+			cfg.applyDefaults()
+			cfg.requireOpenIDScope()
+
+			assert.Equal(t, tt.want, cfg.scopes)
+		})
+	}
+}
+
 func TestWithKeyboardFlow(t *testing.T) {
 	var cfg loginConfig
 	WithKeyboardFlow()(&cfg)


### PR DESCRIPTION
## Summary

`oidc.loginConfig.applyDefaults()` decided whether to apply a default by inspecting the field's **value** (`len(c.scopes) == 0`, `c.timeout == 0`) rather than whether the caller had **set** it. As a result, a caller who explicitly passed a zero value had it silently replaced:

- `WithTimeout(0)` became the 2-minute default.
- `WithScopes()` (explicit empty) became the default scopes, even though `WithScopes` already records `scopesSet`.

This makes `applyDefaults` consult the `*Set` sentinels instead, so defaults fill only genuinely-unset fields. Unset behavior and non-zero explicit values are unchanged.

## Related Issue

Follow-up to a review comment on #3232 (raised by @elezar): https://github.com/NVIDIA/OpenShell/pull/3232#discussion_r3966748160. This is a small, localized pre-existing bug fix, so no separate issue is filed.

## Changes

- `oidc/options.go`: add a `timeoutSet` sentinel (set by `WithTimeout`); `applyDefaults` now checks `!scopesSet` / `!timeoutSet` instead of the zero value.
- `oidc/credentials_auth.go`: guard the client-credentials token exchange so a zero timeout means "no deadline" rather than an already-expired context (matching the existing guards in Login and DeviceFlow).
- Tests: explicit empty scopes and explicit zero timeout are honored; unset still defaults; a client-credentials exchange with `WithTimeout(0)` succeeds instead of failing on a born-expired context.

**Behavior change:** `WithTimeout(0)` now means "no timeout" instead of the 2-minute default.

## Testing

- `mise run go:ci` green (build, `golangci-lint`, `gofmt`, full `go test`, proto-check, docs-check).
- New oidc unit tests plus an end-to-end client-credentials test covering the zero-timeout path.

## Checklist

- [x] Conventional Commit message, DCO sign-off
- [x] Tests added and passing
- [x] No public option-type or entry-point signature changed
- [x] Behavior change (`WithTimeout(0)`) documented above
