### PR TITLE
fix(driver-docker): scope pending sandbox matching by id and workspace

### DIFF
--- a/crates/openshell-driver-docker/src/lib.rs
+++ b/crates/openshell-driver-docker/src/lib.rs
@@ -794,7 +794,7 @@ impl DockerComputeDriver {
             return Ok(Some(sandbox));
         }
 
-        Ok(self.pending_snapshot(sandbox_id, sandbox_name).await)
+        self.pending_snapshot(sandbox_id, sandbox_name).await
     }
 
     async fn current_snapshots(&self) -> Result<Vec<DriverSandbox>, Status> {
@@ -1067,7 +1067,9 @@ impl DockerComputeDriver {
         sandbox_id: &str,
         sandbox_name: &str,
     ) -> Result<bool, Status> {
-        let pending = self.remove_pending_sandbox(sandbox_id, sandbox_name).await;
+        let pending = self
+            .remove_pending_sandbox(sandbox_id, sandbox_name)
+            .await?;
         if let Some(record) = pending.as_ref()
             && let Some(task) = record.task.as_ref()
         {
@@ -1132,7 +1134,10 @@ impl DockerComputeDriver {
             .find_managed_container_summary(sandbox_id, sandbox_name)
             .await?
         else {
-            if let Some(record) = self.remove_pending_sandbox(sandbox_id, sandbox_name).await {
+            if let Some(record) = self
+                .remove_pending_sandbox(sandbox_id, sandbox_name)
+                .await?
+            {
                 if let Some(task) = record.task {
                     task.abort();
                 }
@@ -1249,10 +1254,11 @@ impl DockerComputeDriver {
 
     async fn reserve_pending_sandbox(&self, sandbox: &DriverSandbox) -> Result<(), Status> {
         let mut pending = self.pending.lock().await;
-        if pending
-            .values()
-            .any(|record| record.sandbox.id == sandbox.id || record.sandbox.name == sandbox.name)
-        {
+        if pending.values().any(|record| {
+            record.sandbox.id == sandbox.id
+                || (record.sandbox.name == sandbox.name
+                    && record.sandbox.workspace == sandbox.workspace)
+        }) {
             return Err(Status::already_exists("sandbox already exists"));
         }
 
@@ -1275,12 +1281,12 @@ impl DockerComputeDriver {
         &self,
         sandbox_id: &str,
         sandbox_name: &str,
-    ) -> Option<DriverSandbox> {
+    ) -> Result<Option<DriverSandbox>, Status> {
         let pending = self.pending.lock().await;
-        pending
-            .values()
-            .find(|record| pending_sandbox_matches(&record.sandbox, sandbox_id, sandbox_name))
-            .map(|record| record.sandbox.clone())
+        let Some(id) = resolve_pending_id(&pending, sandbox_id, sandbox_name)? else {
+            return Ok(None);
+        };
+        Ok(pending.get(&id).map(|record| record.sandbox.clone()))
     }
 
     async fn pending_snapshot_map(&self) -> HashMap<String, DriverSandbox> {
@@ -1300,12 +1306,12 @@ impl DockerComputeDriver {
         &self,
         sandbox_id: &str,
         sandbox_name: &str,
-    ) -> Option<PendingSandboxRecord> {
+    ) -> Result<Option<PendingSandboxRecord>, Status> {
         let mut pending = self.pending.lock().await;
-        let id = pending.iter().find_map(|(id, record)| {
-            pending_sandbox_matches(&record.sandbox, sandbox_id, sandbox_name).then(|| id.clone())
-        })?;
-        pending.remove(&id)
+        let Some(id) = resolve_pending_id(&pending, sandbox_id, sandbox_name)? else {
+            return Ok(None);
+        };
+        Ok(pending.remove(&id))
     }
 
     async fn fail_pending_sandbox(
@@ -1560,21 +1566,14 @@ impl DockerComputeDriver {
             .map_err(|err| internal_status("find Docker sandbox container", err))?;
 
         Ok(containers.into_iter().find(|summary| {
-            let Some(labels) = summary.labels.as_ref() else {
-                return false;
-            };
-            let namespace_matches = labels
-                .get(LABEL_SANDBOX_NAMESPACE)
-                .is_some_and(|value| value == &self.config.sandbox_namespace);
-            let id_matches = sandbox_id.is_empty()
-                || labels
-                    .get(LABEL_SANDBOX_ID)
-                    .is_some_and(|value| value == sandbox_id);
-            let name_matches = sandbox_name.is_empty()
-                || labels
-                    .get(LABEL_SANDBOX_NAME)
-                    .is_some_and(|value| value == sandbox_name);
-            namespace_matches && id_matches && name_matches
+            summary.labels.as_ref().is_some_and(|labels| {
+                managed_container_identity_matches(
+                    labels,
+                    &self.config.sandbox_namespace,
+                    sandbox_id,
+                    sandbox_name,
+                )
+            })
         }))
     }
 
@@ -2162,9 +2161,73 @@ fn pending_sandbox_snapshot(
     }
 }
 
-fn pending_sandbox_matches(sandbox: &DriverSandbox, sandbox_id: &str, sandbox_name: &str) -> bool {
-    (!sandbox_id.is_empty() && sandbox.id == sandbox_id)
-        || (!sandbox_name.is_empty() && sandbox.name == sandbox_name)
+/// Decides whether a managed container satisfies a lifecycle request.
+///
+/// `sandbox_id` is authoritative, matching [`resolve_pending_id`]. Requiring
+/// the name to agree as well would discard a correct id match whenever the
+/// caller pairs it with a stale name, leaving the container and its token file
+/// behind while the driver reports the sandbox as absent.
+///
+/// A request with no identifier matches nothing. `require_sandbox_identifier`
+/// rejects that upstream, but the label filters degenerate to "every managed
+/// container in the namespace", so this does not rely on the caller to guard it.
+fn managed_container_identity_matches(
+    labels: &HashMap<String, String>,
+    namespace: &str,
+    sandbox_id: &str,
+    sandbox_name: &str,
+) -> bool {
+    if labels
+        .get(LABEL_SANDBOX_NAMESPACE)
+        .is_none_or(|value| value != namespace)
+    {
+        return false;
+    }
+    if !sandbox_id.is_empty() {
+        return labels
+            .get(LABEL_SANDBOX_ID)
+            .is_some_and(|value| value == sandbox_id);
+    }
+    !sandbox_name.is_empty()
+        && labels
+            .get(LABEL_SANDBOX_NAME)
+            .is_some_and(|value| value == sandbox_name)
+}
+
+/// Resolves a lifecycle request to at most one pending sandbox id.
+///
+/// `sandbox_id` is authoritative: when the caller supplies one, the name is
+/// never consulted as an alternative. The name fallback rejects ambiguity
+/// instead of letting `HashMap` iteration order pick a match, because sandbox
+/// names are unique per workspace and the driver request carries no workspace.
+fn resolve_pending_id(
+    pending: &HashMap<String, PendingSandboxRecord>,
+    sandbox_id: &str,
+    sandbox_name: &str,
+) -> Result<Option<String>, Status> {
+    if !sandbox_id.is_empty() {
+        return Ok(pending
+            .contains_key(sandbox_id)
+            .then(|| sandbox_id.to_string()));
+    }
+    if sandbox_name.is_empty() {
+        return Ok(None);
+    }
+
+    let mut matches = pending
+        .iter()
+        .filter(|(_, record)| record.sandbox.name == sandbox_name)
+        .map(|(id, _)| id.clone());
+
+    let Some(id) = matches.next() else {
+        return Ok(None);
+    };
+    if matches.next().is_some() {
+        return Err(Status::failed_precondition(
+            "sandbox_name matches multiple pending sandboxes; specify sandbox_id",
+        ));
+    }
+    Ok(Some(id))
 }
 
 fn provisioning_condition() -> DriverCondition {

--- a/crates/openshell-driver-docker/src/tests.rs
+++ b/crates/openshell-driver-docker/src/tests.rs
@@ -2877,8 +2877,17 @@ fn pending_sandbox_snapshot_uses_docker_namespace_and_starting_condition() {
     assert_eq!(snapshot.name, "demo");
     assert_eq!(snapshot.namespace, "docker-dev");
     assert!(snapshot.spec.is_none());
-    assert!(pending_sandbox_matches(&snapshot, "sbx-123", ""));
-    assert!(pending_sandbox_matches(&snapshot, "", "demo"));
+    let pending = pending_map(&[&snapshot]);
+    assert_eq!(
+        resolve_pending_id(&pending, "sbx-123", "")
+            .unwrap()
+            .as_deref(),
+        Some("sbx-123")
+    );
+    assert_eq!(
+        resolve_pending_id(&pending, "", "demo").unwrap().as_deref(),
+        Some("sbx-123")
+    );
 
     let status = snapshot.status.expect("status");
     assert!(!status.deleting);
@@ -3350,4 +3359,334 @@ fn docker_oom_kill_stays_terminal_despite_137() {
     };
     apply_docker_exit_classification(&mut sandbox, &state);
     assert_eq!(ready_reason(&sandbox), CONDITION_EXITED);
+}
+
+/// Minimal pending-map entry. Only the identity fields matter for lookup
+/// resolution, so the spec and status are left empty on purpose.
+fn pending_sandbox(id: &str, name: &str, workspace: &str) -> DriverSandbox {
+    DriverSandbox {
+        id: id.to_string(),
+        name: name.to_string(),
+        namespace: String::new(),
+        spec: None,
+        status: None,
+        workspace: workspace.to_string(),
+    }
+}
+
+fn pending_map(sandboxes: &[&DriverSandbox]) -> HashMap<String, PendingSandboxRecord> {
+    sandboxes
+        .iter()
+        .map(|sandbox| {
+            (
+                sandbox.id.clone(),
+                PendingSandboxRecord {
+                    sandbox: (*sandbox).clone(),
+                    task: None,
+                },
+            )
+        })
+        .collect()
+}
+
+async fn driver_with_pending(sandboxes: &[&DriverSandbox]) -> DockerComputeDriver {
+    let driver = test_driver_with_config(runtime_config());
+    for sandbox in sandboxes {
+        driver
+            .reserve_pending_sandbox(sandbox)
+            .await
+            .expect("reserving a distinct sandbox must succeed");
+    }
+    driver
+}
+
+fn pending_ids(pending: &HashMap<String, DriverSandbox>) -> Vec<String> {
+    let mut ids: Vec<String> = pending.keys().cloned().collect();
+    ids.sort();
+    ids
+}
+
+#[test]
+fn resolve_pending_id_prefers_sandbox_id_over_sandbox_name() {
+    // The id is authoritative. A stale or mismatched name travelling in the
+    // same request must not change which record is resolved.
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let pending = pending_map(&[&alpha]);
+
+    assert_eq!(
+        resolve_pending_id(&pending, "sbx-alpha", "stale-name")
+            .unwrap()
+            .as_deref(),
+        Some("sbx-alpha")
+    );
+}
+
+#[test]
+fn resolve_pending_id_ignores_the_name_when_the_id_is_not_pending() {
+    // Regression for the `id OR name` match. `demo` exists in two workspaces:
+    // the beta copy is still provisioning, the alpha copy is already running.
+    // Deleting the alpha copy sends alpha's id plus the shared name. Matching
+    // on the name alone resolved to the beta record and evicted it, aborting
+    // an unrelated sandbox's provisioning task.
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let pending = pending_map(&[&beta]);
+
+    assert_eq!(
+        resolve_pending_id(&pending, "sbx-alpha", "demo").unwrap(),
+        None
+    );
+}
+
+#[test]
+fn resolve_pending_id_falls_back_to_the_name_when_no_id_is_supplied() {
+    // Direct driver callers may omit the id; a unique name still resolves.
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let pending = pending_map(&[&alpha]);
+
+    assert_eq!(
+        resolve_pending_id(&pending, "", "demo").unwrap().as_deref(),
+        Some("sbx-alpha")
+    );
+}
+
+#[test]
+fn resolve_pending_id_rejects_an_ambiguous_name_only_lookup() {
+    // Two pending sandboxes share a name across workspaces and the driver
+    // request carries no workspace. Picking either one would make the outcome
+    // depend on `HashMap` iteration order, so refuse instead.
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let pending = pending_map(&[&alpha, &beta]);
+
+    let err = resolve_pending_id(&pending, "", "demo")
+        .expect_err("an ambiguous name-only lookup must be rejected");
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+}
+
+#[test]
+fn resolve_pending_id_returns_none_without_any_identifier() {
+    // `require_sandbox_identifier` rejects this upstream, but the resolver
+    // stays total so an empty request can never match an arbitrary record.
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let pending = pending_map(&[&alpha]);
+
+    assert_eq!(resolve_pending_id(&pending, "", "").unwrap(), None);
+}
+
+#[tokio::test]
+async fn remove_pending_sandbox_by_id_keeps_a_same_named_sandbox_in_another_workspace() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let driver = driver_with_pending(&[&alpha, &beta]).await;
+
+    let removed = driver
+        .remove_pending_sandbox("sbx-alpha", "demo")
+        .await
+        .expect("an id-scoped removal must succeed")
+        .expect("the alpha record must be removed");
+
+    assert_eq!(removed.sandbox.id, "sbx-alpha");
+    assert_eq!(
+        pending_ids(&driver.pending_snapshot_map().await),
+        ["sbx-beta"]
+    );
+}
+
+#[tokio::test]
+async fn remove_pending_sandbox_by_a_unique_name_still_removes_the_record() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let driver = driver_with_pending(&[&alpha]).await;
+
+    let removed = driver
+        .remove_pending_sandbox("", "demo")
+        .await
+        .expect("a unique name-only removal must succeed")
+        .expect("the alpha record must be removed");
+
+    assert_eq!(removed.sandbox.id, "sbx-alpha");
+    assert!(driver.pending_snapshot_map().await.is_empty());
+}
+
+#[tokio::test]
+async fn remove_pending_sandbox_rejects_an_ambiguous_name_and_keeps_both_records() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let driver = driver_with_pending(&[&alpha, &beta]).await;
+
+    let err = driver
+        .remove_pending_sandbox("", "demo")
+        .await
+        .map(|record| record.map(|record| record.sandbox.id))
+        .expect_err("an ambiguous name-only removal must be rejected");
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(
+        pending_ids(&driver.pending_snapshot_map().await),
+        ["sbx-alpha", "sbx-beta"]
+    );
+}
+
+#[tokio::test]
+async fn pending_snapshot_by_id_ignores_a_same_named_sandbox_in_another_workspace() {
+    // `GetSandbox` falls through to the pending map when no container exists.
+    // Resolving by name there leaked another workspace's snapshot.
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let driver = driver_with_pending(&[&beta]).await;
+
+    assert!(
+        driver
+            .pending_snapshot("sbx-alpha", "demo")
+            .await
+            .expect("an id-scoped snapshot lookup must succeed")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn pending_snapshot_rejects_an_ambiguous_name_only_lookup() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let driver = driver_with_pending(&[&alpha, &beta]).await;
+
+    let err = driver
+        .pending_snapshot("", "demo")
+        .await
+        .expect_err("an ambiguous name-only snapshot lookup must be rejected");
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+}
+
+#[tokio::test]
+async fn reserve_pending_sandbox_allows_the_same_name_in_a_different_workspace() {
+    // Sandbox names are unique per workspace, so this is a legitimate create.
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let beta = pending_sandbox("sbx-beta", "demo", "beta");
+    let driver = driver_with_pending(&[&alpha]).await;
+
+    driver
+        .reserve_pending_sandbox(&beta)
+        .await
+        .expect("a same-named sandbox in another workspace must be allowed");
+
+    assert_eq!(
+        pending_ids(&driver.pending_snapshot_map().await),
+        ["sbx-alpha", "sbx-beta"]
+    );
+}
+
+#[tokio::test]
+async fn reserve_pending_sandbox_rejects_a_duplicate_name_in_the_same_workspace() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let duplicate = pending_sandbox("sbx-other", "demo", "alpha");
+    let driver = driver_with_pending(&[&alpha]).await;
+
+    let err = driver
+        .reserve_pending_sandbox(&duplicate)
+        .await
+        .expect_err("a duplicate name within one workspace must be rejected");
+
+    assert_eq!(err.code(), tonic::Code::AlreadyExists);
+    assert_eq!(
+        pending_ids(&driver.pending_snapshot_map().await),
+        ["sbx-alpha"]
+    );
+}
+
+#[tokio::test]
+async fn reserve_pending_sandbox_rejects_a_duplicate_id() {
+    let alpha = pending_sandbox("sbx-alpha", "demo", "alpha");
+    let duplicate = pending_sandbox("sbx-alpha", "other-name", "beta");
+    let driver = driver_with_pending(&[&alpha]).await;
+
+    let err = driver
+        .reserve_pending_sandbox(&duplicate)
+        .await
+        .expect_err("a duplicate sandbox id must be rejected regardless of workspace");
+
+    assert_eq!(err.code(), tonic::Code::AlreadyExists);
+    assert_eq!(
+        pending_ids(&driver.pending_snapshot_map().await),
+        ["sbx-alpha"]
+    );
+}
+
+fn managed_container_labels(
+    namespace: &str,
+    sandbox_id: &str,
+    sandbox_name: &str,
+) -> HashMap<String, String> {
+    HashMap::from([
+        (
+            LABEL_MANAGED_BY.to_string(),
+            LABEL_MANAGED_BY_VALUE.to_string(),
+        ),
+        (LABEL_SANDBOX_NAMESPACE.to_string(), namespace.to_string()),
+        (LABEL_SANDBOX_ID.to_string(), sandbox_id.to_string()),
+        (LABEL_SANDBOX_NAME.to_string(), sandbox_name.to_string()),
+    ])
+}
+
+#[test]
+fn managed_container_identity_matches_on_id_despite_a_stale_name() {
+    // Requiring the name to agree with an authoritative id dropped the match
+    // and made the driver report a live sandbox as absent, stranding the
+    // container and leaking its token file.
+    let labels = managed_container_labels("default", "sbx-alpha", "demo");
+
+    assert!(managed_container_identity_matches(
+        &labels,
+        "default",
+        "sbx-alpha",
+        "stale-name"
+    ));
+}
+
+#[test]
+fn managed_container_identity_rejects_a_name_match_when_the_id_differs() {
+    // The mirror of the pending-map fix: a shared name must not stand in for
+    // an id that explicitly disagrees.
+    let labels = managed_container_labels("default", "sbx-beta", "demo");
+
+    assert!(!managed_container_identity_matches(
+        &labels,
+        "default",
+        "sbx-alpha",
+        "demo"
+    ));
+}
+
+#[test]
+fn managed_container_identity_falls_back_to_the_name_without_an_id() {
+    let labels = managed_container_labels("default", "sbx-alpha", "demo");
+
+    assert!(managed_container_identity_matches(
+        &labels, "default", "", "demo"
+    ));
+    assert!(!managed_container_identity_matches(
+        &labels, "default", "", "other"
+    ));
+}
+
+#[test]
+fn managed_container_identity_matches_nothing_without_an_identifier() {
+    // The label filters degenerate to "every managed container in the
+    // namespace" when neither identifier is supplied, so the predicate must
+    // not wave the container through.
+    let labels = managed_container_labels("default", "sbx-alpha", "demo");
+
+    assert!(!managed_container_identity_matches(
+        &labels, "default", "", ""
+    ));
+}
+
+#[test]
+fn managed_container_identity_requires_the_configured_namespace() {
+    let labels = managed_container_labels("other-namespace", "sbx-alpha", "demo");
+
+    assert!(!managed_container_identity_matches(
+        &labels,
+        "default",
+        "sbx-alpha",
+        "demo"
+    ));
 }


### PR DESCRIPTION
## Summary

Pending-sandbox lookups in the Docker compute driver matched on `sandbox_id` **OR** `sandbox_name`. Sandbox names are unique per workspace, not globally, so a lifecycle request carrying a correct id could resolve to a different sandbox that happened to share a name in another workspace — evicting its pending record and aborting its in-flight provisioning task. This makes `sandbox_id` authoritative, rejects ambiguous name-only lookups instead of letting `HashMap` iteration order pick a victim, and scopes the reserve-time name-conflict check by workspace.

## Related Issue

Fixes #3234

## Changes

- Replace `pending_sandbox_matches` with `resolve_pending_id`, which resolves a lifecycle request to at most one pending sandbox id:
  - `sandbox_id` is authoritative — when supplied, the name is never consulted as an alternative. Previously an id that was absent from the pending map fell through to a name match.
  - The name fallback now applies only when no id is supplied, and returns `FailedPrecondition` when more than one pending sandbox shares the name. The driver request carries no workspace, so the match is genuinely ambiguous and the previous behavior depended on `HashMap` iteration order.
  - The id path is a keyed lookup rather than a linear scan; the map is already keyed by `sandbox.id`.
- Thread the resulting `Result` through `pending_snapshot`, `remove_pending_sandbox`, and their callers in `get_sandbox_snapshot`, `delete_sandbox_inner`, and `stop_sandbox_inner`.
- Scope the `reserve_pending_sandbox` name-conflict check by workspace. Creating a sandbox named `demo` in workspace `beta` while a `demo` in workspace `alpha` was still provisioning previously failed with `AlreadyExists`. Duplicate ids are still rejected unconditionally. This uses `DriverSandbox.workspace`, which the driver already receives — no proto change.

### Behavior change

An ambiguous name-only `DeleteSandbox`/`StopSandbox`/`GetSandbox` now returns `FailedPrecondition` rather than acting on an arbitrary match. The gateway always sends a non-empty `sandbox_id` (`crates/openshell-server/src/compute/mod.rs`), so this path is reachable only by direct driver RPCs.

### Out of scope

- Adding `workspace` to the driver-facing `DeleteSandboxRequest`/`StopSandboxRequest`/`StartSandboxRequest`. It would let the name fallback disambiguate instead of erroring, but it touches five driver crates and the driver proto contract, so it belongs in its own change. The public `DeleteSandboxRequest` in `proto/openshell.proto` already carries `workspace`; the driver-facing message in `proto/compute_driver.proto` does not.
- `crates/openshell-driver-vm` (`driver.rs:1391`, `:1471`, `:1536`, `:1617`) and `crates/openshell-driver-mxc` (`driver.rs:345`) resolve in-memory records by name with the same weakness. Podman and Kubernetes are unaffected — they resolve against platform labels. I have reviewed the matching shape in those drivers but not traced their full call paths; filing separately rather than expanding this PR.


## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [x] `mise run pre-commit` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
