### PR TITLE
fix(helm): harden certgen security context

### DIFF
--- a/deploy/helm/openshell/README.md
+++ b/deploy/helm/openshell/README.md
@@ -204,6 +204,8 @@ discovery endpoint or its TLS CA.
 | openshiftRoute.enabled | bool | `false` | Create an OpenShift Route with TLS passthrough. |
 | openshiftRoute.host | string | `""` | Hostname for the Route. Must match a SAN on the gateway's server cert. |
 | pkiInitJob.enabled | bool | `true` | Run a pre-install/pre-upgrade Job that creates gateway and client mTLS Secrets. When certManager.enabled=true, cert-manager owns TLS and this same hook runs in JWT-only mode even if pkiInitJob.enabled remains true. |
+| pkiInitJob.podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context for the certificate-generation hook. |
+| pkiInitJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Container security context for the certificate-generation hook. |
 | pkiInitJob.serverDnsNames | list | `[]` | Extra DNS SANs to append to the server certificate. |
 | pkiInitJob.serverIpAddresses | list | `[]` | Extra IP SANs to append to the server certificate. |
 | podAnnotations | object | `{}` | Extra annotations to add to the gateway pod. |

--- a/deploy/helm/openshell/templates/certgen.yaml
+++ b/deploy/helm/openshell/templates/certgen.yaml
@@ -74,6 +74,8 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $hookName }}
+      securityContext:
+        {{- toYaml .Values.pkiInitJob.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -83,10 +85,7 @@ spec:
           image: {{ include "openshell.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.pkiInitJob.securityContext | nindent 12 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/helm/openshell/tests/certgen_test.yaml
+++ b/deploy/helm/openshell/tests/certgen_test.yaml
@@ -34,6 +34,53 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--jwt-only"
         documentIndex: 3
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+        documentIndex: 3
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+        documentIndex: 3
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+        documentIndex: 3
+
+  - it: supports certgen-specific security context overrides
+    template: templates/certgen.yaml
+    set:
+      pkiInitJob.podSecurityContext:
+        runAsNonRoot: false
+        seccompProfile:
+          type: Localhost
+          localhostProfile: profiles/certgen.json
+      pkiInitJob.securityContext:
+        runAsNonRoot: false
+        runAsUser: 1234
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: false
+            seccompProfile:
+              type: Localhost
+              localhostProfile: profiles/certgen.json
+        documentIndex: 3
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsNonRoot: false
+            runAsUser: 1234
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        documentIndex: 3
 
   - it: renders JWT-only certgen hook when cert-manager owns TLS
     template: templates/certgen.yaml

--- a/deploy/helm/openshell/values.yaml
+++ b/deploy/helm/openshell/values.yaml
@@ -455,6 +455,18 @@ pkiInitJob:
   # Secrets. When certManager.enabled=true, cert-manager owns TLS and this same
   # hook runs in JWT-only mode even if pkiInitJob.enabled remains true.
   enabled: true
+  # -- Pod security context for the certificate-generation hook.
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Container security context for the certificate-generation hook.
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   # -- Extra DNS SANs to append to the server certificate.
   serverDnsNames: []
   # -- Extra IP SANs to append to the server certificate.

--- a/skills/debug-openshell-cluster/SKILL.md
+++ b/skills/debug-openshell-cluster/SKILL.md
@@ -330,6 +330,13 @@ If the gateway pod is pending with `MountVolume.SetUp failed for volume
 `templates/certgen.yaml` output and the hook Job logs; cert-manager creates TLS
 Secrets but does not create the sandbox JWT signing Secret.
 
+The certgen hook defaults to a Restricted Pod Security-compatible pod and
+container security context. If admission rejects it, inspect the effective
+`pkiInitJob.podSecurityContext` and `pkiInitJob.securityContext` values and the
+rendered Job; overrides must retain `runAsNonRoot: true`, a `RuntimeDefault` or
+`Localhost` seccomp profile, `allowPrivilegeEscalation: false`, and dropped
+`ALL` capabilities.
+
 If the gateway exits with `failed to read sandbox JWT signing key from
 /etc/openshell-jwt/signing.pem`, verify that `openshell-jwt-keys` contains
 `signing.pem`, `public.pem`, and `kid`, and that the gateway workload mounts the


### PR DESCRIPTION
## Summary

Harden the Helm certgen hook for namespaces enforcing the Kubernetes Restricted Pod Security Standard.

- default the certgen pod to `runAsNonRoot` with `RuntimeDefault` seccomp
- default the certgen container to no privilege escalation with all capabilities dropped
- expose certgen-specific pod and container security-context overrides
- cover defaults and overrides with Helm unit tests
- document the values and troubleshooting behavior

Fixes #3215

## Testing

- `mise run helm:test` (127 tests passed)
- `mise run helm:lint`
- `mise run helm:docs:check`
- `git diff --check`

AI assistance was used for implementation and review; I inspected the changes and ran the listed validation.
