### PR TITLE
ci(security): orchestrate scans with high/critical gating

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -7,6 +7,16 @@ on:
   schedule:
     - cron: "23 7 * * *"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      candidate_ref:
+        description: Optional pre-release tag to scan instead of the triggering revision
+        default: ""
+        type: string
+      advisories-only:
+        description: Run only the dependency advisory check
+        default: false
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,7 +27,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: cargo-deny-${{ github.workflow }}-${{ inputs.candidate_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,9 +41,16 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
 
       - name: Install tools
         run: mise install --locked
 
       - name: Check dependencies
+        if: ${{ !inputs.advisories-only }}
         run: mise run rust:deny
+
+      - name: Check dependency advisories
+        if: inputs.advisories-only
+        run: cargo deny check advisories

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,13 +7,23 @@ on:
   schedule:
     - cron: "29 5 * * *"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      candidate_ref:
+        description: Optional pre-release tag to scan instead of the triggering revision
+        default: ""
+        type: string
+      fail-on-findings:
+        description: Fail on HIGH/CRITICAL security findings (score at least 7.0)
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: codeql-${{ github.workflow }}-${{ inputs.candidate_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -38,7 +48,9 @@ jobs:
             build-mode: none
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        id: checkout
         with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
           persist-credentials: false
 
       - name: Set up Go
@@ -69,9 +81,11 @@ jobs:
           upload: never
 
       - name: Summarize findings
+        id: findings
         if: always()
         env:
           LANGUAGE: ${{ matrix.language }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
         shell: bash
         run: |
           set -euo pipefail
@@ -83,11 +97,23 @@ jobs:
             echo
             if [ "${#sarif_files[@]}" -eq 0 ]; then
               echo "No SARIF report was produced."
+              exit 1
             else
-              finding_count=$(jq -s '[.[].runs[]?.results[]?] | length' "${sarif_files[@]}")
+              finding_count=$(jq -s '[.[].runs[].results[]] | length' "${sarif_files[@]}")
+              high_count=$(jq -s '
+                [ .[].runs[] | . as $run | .results[]
+                  | select(all(.suppressions[]?; .status != "accepted"))
+                  | .ruleId as $id
+                  | ($run.tool.driver, $run.tool.extensions[]?) | .rules[]?
+                  | select(.id == $id)
+                  | select((.properties["security-severity"] // "0" | tonumber) >= 7)
+                ] | length
+              ' "${sarif_files[@]}")
+              echo "high_count=$high_count" >> "$GITHUB_OUTPUT"
               echo "Findings: $finding_count"
+              echo "HIGH/CRITICAL: $high_count"
               echo
-              echo "Findings are informational and do not fail CI."
+              echo "Fail on HIGH/CRITICAL: $FAIL_ON_FINDINGS"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -96,6 +122,8 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: codeql-results
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
+          sha: ${{ inputs.candidate_ref && steps.checkout.outputs.commit || '' }}
           category: /language:${{ matrix.language }}
 
       - name: Upload SARIF
@@ -107,8 +135,22 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Enforce HIGH/CRITICAL threshold
+        if: ${{ !cancelled() && steps.findings.outcome == 'success' }}
+        env:
+          HIGH_COUNT: ${{ steps.findings.outputs.high_count }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
+        run: |
+          if [ "$HIGH_COUNT" -gt 0 ]; then
+            if [ "$FAIL_ON_FINDINGS" = "true" ]; then
+              echo "::error::CodeQL reported $HIGH_COUNT HIGH/CRITICAL findings."
+              exit 1
+            fi
+            echo "::warning::CodeQL reported $HIGH_COUNT HIGH/CRITICAL findings; enforcement is disabled."
+          fi
+
   result:
-    name: OpenShell / CodeQL (informational)
+    name: ${{ inputs.fail-on-findings && 'OpenShell / CodeQL' || 'OpenShell / CodeQL (informational)' }}
     if: always()
     needs: analyze
     runs-on: ubuntu-latest
@@ -120,7 +162,7 @@ jobs:
         shell: bash
         run: |
           if [ "$ANALYZE_RESULT" != "success" ]; then
-            echo "::error::One or more CodeQL analyzers did not complete successfully."
+            echo "::error::CodeQL execution or the configured finding threshold failed."
             exit 1
           fi
-          echo "All CodeQL analyzers completed; findings remain informational."
+          echo "All CodeQL analyzers completed and the configured finding threshold passed."

--- a/.github/workflows/codex-security.yml
+++ b/.github/workflows/codex-security.yml
@@ -23,6 +23,14 @@ on:
         required: false
         default: false
         type: boolean
+      fail-on-findings:
+        description: Fail on HIGH/CRITICAL security findings
+        default: false
+        type: boolean
+      upload_sarif:
+        description: Upload results to Code Scanning when called from a manual workflow
+        default: true
+        type: boolean
     outputs:
       base_sha:
         description: Previous stable commit, empty for a full bootstrap scan
@@ -230,6 +238,7 @@ jobs:
             --output "$SARIF_FILE"
 
       - name: Summarize findings
+        id: findings
         env:
           BASE_TAG: ${{ steps.range.outputs.base_tag }}
           CANDIDATE_TAG: ${{ steps.range.outputs.candidate_tag }}
@@ -237,9 +246,17 @@ jobs:
           SARIF_FILE: ${{ runner.temp }}/codex-security.sarif
           SCAN_SCOPE: ${{ steps.range.outputs.scan_scope }}
           TRAIN: ${{ steps.range.outputs.train }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
         run: |
           set -euo pipefail
-          finding_count=$(jq '[.runs[]?.results[]?] | length' "$SARIF_FILE")
+          finding_count=$(jq '[.runs[].results[]] | length' "$SARIF_FILE")
+          high_count=$(jq '
+            [ .runs[].results[]
+              | select(all(.suppressions[]?; .status != "accepted"))
+              | select(.properties.severity | ascii_downcase | IN("high", "critical"))
+            ] | length
+          ' "$SARIF_FILE")
+          echo "high_count=$high_count" >> "$GITHUB_OUTPUT"
           {
             echo "### Codex Security release qualification"
             echo
@@ -254,8 +271,9 @@ jobs:
             fi
             echo "- Coverage: complete"
             echo "- Findings: $finding_count"
+            echo "- HIGH/CRITICAL: $high_count"
             echo
-            echo "Findings are informational during the observation phase."
+            echo "Fail on HIGH/CRITICAL: $FAIL_ON_FINDINGS"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SARIF to Code Scanning
@@ -267,8 +285,22 @@ jobs:
           sha: ${{ steps.range.outputs.candidate_sha }}
           category: ${{ steps.range.outputs.category }}
 
+      - name: Enforce HIGH/CRITICAL threshold
+        if: ${{ !cancelled() && steps.findings.outcome == 'success' }}
+        env:
+          HIGH_COUNT: ${{ steps.findings.outputs.high_count }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
+        run: |
+          if [ "$HIGH_COUNT" -gt 0 ]; then
+            if [ "$FAIL_ON_FINDINGS" = "true" ]; then
+              echo "::error::Codex reported $HIGH_COUNT HIGH/CRITICAL findings."
+              exit 1
+            fi
+            echo "::warning::Codex reported $HIGH_COUNT HIGH/CRITICAL findings; enforcement is disabled."
+          fi
+
   result:
-    name: OpenShell / Codex Security (informational)
+    name: ${{ inputs.fail-on-findings && 'OpenShell / Codex Security' || 'OpenShell / Codex Security (informational)' }}
     if: ${{ always() }}
     needs: analyze
     runs-on: ubuntu-latest
@@ -283,4 +315,4 @@ jobs:
             echo "::error::Codex Security release qualification did not complete successfully."
             exit 1
           fi
-          echo "Codex Security completed; findings remain informational."
+          echo "Codex Security completed and the configured finding threshold passed."

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Security Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: Pre-release tag to scan (vMAJOR.MINOR.PATCH-pre.N)
+        required: true
+        type: string
+      stable_ref:
+        description: Optional previous stable tag override for Codex
+        default: ""
+        type: string
+      allow_full_bootstrap:
+        description: Allow a full Codex scan when no previous stable tag exists
+        default: false
+        type: boolean
+      allow-high-critical:
+        description: Report HIGH/CRITICAL findings without failing; scanner errors still fail
+        default: false
+        type: boolean
+      images:
+        description: Newline-separated image references for Trivy
+        default: ""
+        type: string
+      charts:
+        description: Newline-separated packaged Helm chart OCI references for Trivy
+        default: ""
+        type: string
+  workflow_call:
+    inputs:
+      candidate_ref:
+        description: Pre-release tag to scan (vMAJOR.MINOR.PATCH-pre.N)
+        required: true
+        type: string
+      stable_ref:
+        description: Optional previous stable tag override for Codex
+        default: ""
+        type: string
+      allow_full_bootstrap:
+        description: Allow a full Codex scan when no previous stable tag exists
+        default: false
+        type: boolean
+      allow-high-critical:
+        description: Report HIGH/CRITICAL findings without failing; scanner errors still fail
+        default: false
+        type: boolean
+      images:
+        description: Newline-separated image references for Trivy
+        default: ""
+        type: string
+      charts:
+        description: Newline-separated packaged Helm chart OCI references for Trivy
+        default: ""
+        type: string
+    secrets:
+      CODEX_SECURITY_API_KEY:
+        required: true
+      CACHIX_AUTH_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+# Only the finding threshold is overridable; execution failures remain fatal.
+jobs:
+  codex:
+    name: Codex Security
+    uses: ./.github/workflows/codex-security.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      candidate_ref: ${{ inputs.candidate_ref }}
+      stable_ref: ${{ inputs.stable_ref }}
+      allow_full_bootstrap: ${{ inputs.allow_full_bootstrap }}
+      fail-on-findings: ${{ !inputs.allow-high-critical }}
+      upload_sarif: true
+    secrets:
+      CODEX_SECURITY_API_KEY: ${{ secrets.CODEX_SECURITY_API_KEY }}
+
+  codeql:
+    name: CodeQL
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      candidate_ref: ${{ inputs.candidate_ref }}
+      fail-on-findings: ${{ !inputs.allow-high-critical }}
+
+  trivy:
+    name: Trivy
+    uses: ./.github/workflows/trivy-scan.yml
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    with:
+      candidate_ref: ${{ inputs.candidate_ref }}
+      fail-on-findings: ${{ !inputs.allow-high-critical }}
+      severity: HIGH,CRITICAL
+      ignore-unfixed: false
+      images: ${{ inputs.images }}
+      charts: ${{ inputs.charts }}
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  cargo-deny:
+    name: Cargo Deny
+    uses: ./.github/workflows/cargo-deny.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      candidate_ref: ${{ inputs.candidate_ref }}
+      advisories-only: true
+
+  workflow-security:
+    name: Actionlint and Zizmor
+    uses: ./.github/workflows/workflow-security.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      candidate_ref: ${{ inputs.candidate_ref }}
+      fail-on-findings: ${{ !inputs.allow-high-critical }}
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -9,6 +9,10 @@ name: Trivy Scan
 on:
   workflow_call:
     inputs:
+      candidate_ref:
+        description: Optional pre-release tag to scan instead of the triggering revision
+        default: ""
+        type: string
       images:
         description: Newline-separated image references to scan
         type: string
@@ -77,7 +81,7 @@ env:
 
 jobs:
   scan:
-    name: OpenShell / Trivy (informational)
+    name: ${{ inputs.fail-on-findings && 'OpenShell / Trivy' || 'OpenShell / Trivy (informational)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:
@@ -89,6 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
           persist-credentials: false
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -203,7 +208,9 @@ jobs:
         batch: ${{ fromJSON(needs.scan.outputs.sarif-batches) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        id: checkout
         with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
           persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -217,3 +224,5 @@ jobs:
       - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: reports/trivy/code-scanning/uploads/${{ matrix.batch }}
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
+          sha: ${{ inputs.candidate_ref && steps.checkout.outputs.commit || '' }}

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -12,6 +12,19 @@ on:
   schedule:
     - cron: "17 6 * * 1"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      candidate_ref:
+        description: Optional pre-release tag to scan instead of the triggering revision
+        default: ""
+        type: string
+      fail-on-findings:
+        description: Fail on Zizmor HIGH findings; Actionlint remains informational
+        default: false
+        type: boolean
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -21,7 +34,7 @@ defaults:
     shell: nix develop --command bash -euo pipefail {0}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: workflow-security-${{ github.workflow }}-${{ inputs.candidate_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,7 +46,9 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        id: checkout
         with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
           persist-credentials: false
 
       - name: Set up Nix
@@ -95,6 +110,8 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: reports/actionlint.sarif
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
+          sha: ${{ inputs.candidate_ref && steps.checkout.outputs.commit || '' }}
           category: actionlint
 
       - name: Upload Actionlint report
@@ -109,14 +126,16 @@ jobs:
           retention-days: 14
 
   zizmor:
-    name: Zizmor High report (informational)
+    name: ${{ inputs.fail-on-findings && 'Zizmor High report' || 'Zizmor High report (informational)' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        id: checkout
         with:
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
           persist-credentials: false
 
       - name: Set up Nix
@@ -125,6 +144,9 @@ jobs:
           cachix-auth-token: ${{ github.event_name != 'pull_request' && secrets.CACHIX_AUTH_TOKEN || '' }}
 
       - name: Run Zizmor
+        id: findings
+        env:
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
         run: |
           set -euo pipefail
           mkdir -p reports
@@ -145,7 +167,10 @@ jobs:
             --format=sarif \
             . > reports/zizmor-high.sarif
 
-          finding_count=$(jq 'length' reports/zizmor-high.json)
+          finding_count=$(jq '
+            [.[] | select(.ignored != true and .determinations.severity == "High")] | length
+          ' reports/zizmor-high.json)
+          echo "high_count=$finding_count" >> "$GITHUB_OUTPUT"
           {
             echo "### Zizmor high-severity report"
             echo
@@ -158,12 +183,12 @@ jobs:
                 'group_by(.ident) | .[] | "- `\(.[0].ident)`: \(length)"' \
                 reports/zizmor-high.json
               echo
-              echo "These findings are informational and do not fail CI."
+              echo "Fail on HIGH findings: $FAIL_ON_FINDINGS"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$finding_count" -gt 0 ]; then
-            echo "::warning::Zizmor reported $finding_count high-severity findings; this check is informational."
+            echo "::warning::Zizmor reported $finding_count high-severity findings."
           fi
 
       - name: Upload Zizmor SARIF to Code Scanning
@@ -171,6 +196,8 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: reports/zizmor-high.sarif
+          ref: ${{ inputs.candidate_ref && format('refs/tags/{0}', inputs.candidate_ref) || '' }}
+          sha: ${{ inputs.candidate_ref && steps.checkout.outputs.commit || '' }}
           category: zizmor-high
 
       - name: Upload Zizmor reports
@@ -183,3 +210,17 @@ jobs:
             reports/zizmor-high.sarif
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Enforce HIGH/CRITICAL threshold
+        if: ${{ !cancelled() && steps.findings.outcome == 'success' }}
+        env:
+          HIGH_COUNT: ${{ steps.findings.outputs.high_count }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings || false }}
+        run: |
+          if [ "$HIGH_COUNT" -gt 0 ]; then
+            if [ "$FAIL_ON_FINDINGS" = "true" ]; then
+              echo "::error::Zizmor reported $HIGH_COUNT HIGH findings."
+              exit 1
+            fi
+            echo "::warning::Zizmor reported $HIGH_COUNT HIGH findings; enforcement is disabled."
+          fi

--- a/CI.md
+++ b/CI.md
@@ -81,12 +81,93 @@ nix develop --command actionlint -shellcheck= -pyflakes=
 nix develop --command zizmor --offline --persona=regular --min-severity=high --no-exit-codes .
 ```
 
+## Run the security scans together
+
+`Security Scan` (`.github/workflows/security-scan.yml`) calls Codex Security,
+CodeQL, Trivy, Cargo Deny, and Workflow Security Reports (Actionlint/Zizmor) in
+parallel. Run it manually from Actions or call it from another workflow. All
+children scan `candidate_ref`, which must be an existing `vX.Y.Z-pre.N` tag
+because Codex qualifies pre-releases. Codex compares it with the previous stable;
+the other scanners analyze the candidate snapshot. Cargo Deny uses its existing
+NVIDIA self-hosted runner and CI container.
+
+```shell
+gh workflow run security-scan.yml --ref main \
+  -f candidate_ref=v0.1.1-pre.1 \
+  -F allow-high-critical=true
+```
+
+To integrate it into a larger workflow, run it after the job that pushes the
+candidate tag and publishes the artifacts. This example assumes an existing
+`build` job with outputs named `candidate_tag`, `gateway_image`, `sandbox_image`,
+and `chart_ref`; adapt those names to your workflow:
+
+```yaml
+jobs:
+  security:
+    needs: build
+    uses: ./.github/workflows/security-scan.yml
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    with:
+      candidate_ref: ${{ needs.build.outputs.candidate_tag }}
+      stable_ref: v0.1.0 # Optional; otherwise resolved automatically.
+      images: |
+        ${{ needs.build.outputs.gateway_image }}
+        ${{ needs.build.outputs.sandbox_image }}
+      charts: ${{ needs.build.outputs.chart_ref }}
+      allow-high-critical: false
+    secrets:
+      CODEX_SECURITY_API_KEY: ${{ secrets.CODEX_SECURITY_API_KEY }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+```
+
+Set `needs: security` on a downstream promotion job to require successful scans.
+
+`CODEX_SECURITY_API_KEY` is required; `CACHIX_AUTH_TOKEN` is optional. The parent
+publishes SARIF, including Codex results for manual parent runs. Codex keeps its
+release-train category on `main`; CodeQL, Trivy, and workflow reports publish
+against the candidate tag and commit. Existing standalone triggers stay active.
+
+The parent fails on HIGH/CRITICAL findings from Codex, CodeQL, Trivy, and Zizmor.
+Set `allow-high-critical: true` to report those findings without failing; it
+defaults to `false`. Scanner setup, execution, and report publication errors
+still fail. Reports are published before the finding threshold is enforced.
+
+Codex uses each finding's severity; CodeQL uses the rule's security score
+(at least 7.0); Trivy uses `HIGH,CRITICAL`, including vulnerabilities without an
+upstream fix; Zizmor uses its High severity. Actionlint remains informational.
+Existing scanner exceptions still apply.
+
+Cargo Deny runs only `cargo deny check advisories` in the parent. It keeps its
+native failure behavior and configured exceptions, regardless of
+`allow-high-critical`; it has no HIGH/CRITICAL filter. Its standalone runs still
+check all dependency policies.
+
+Codex scans the cumulative diff from `stable_ref` to `candidate_ref`. Both inputs
+are tag names, not arbitrary commit SHAs. Omit `stable_ref` to resolve the previous
+stable automatically; set `allow_full_bootstrap: true` to permit a full scan when
+no previous stable exists.
+
+Trivy accepts optional `images` and `charts`, one reference per line. Images can
+use tags or digests, such as `ghcr.io/nvidia/openshell/gateway:0.1.1-pre.1` or
+`ghcr.io/nvidia/openshell/gateway@sha256:<digest>`. Charts use versioned OCI
+references, such as `oci://ghcr.io/nvidia/openshell/helm-chart:0.1.1-pre.1`.
+Artifacts must already be published and accessible to the workflow. The caller
+selects artifacts matching the candidate; the workflow does not verify that
+association. Without artifact inputs, Trivy scans only the candidate's deployment
+configuration.
+Dependency Review and Trivy Changes keep their separate comparison workflows.
+
 ## Artifact scanning
 
 `Trivy Scan` is a self-contained `workflow_dispatch`/`workflow_call` step. It
 always scans deployment configuration and optionally scans supplied OCI image
-and chart references. It is not wired into a release workflow; a future analysis
-orchestrator can call it directly.
+and chart references. `Security Scan` calls it alongside the other independent
+scanners; release workflows can also call it directly.
 
 The scan job checks static deployment files (including Dockerfiles) once, both
 local charts with default values, the OpenShell `HELM_PROFILES` selected in

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -344,12 +344,32 @@ Triggers differ by workflow: `.github/workflows/workflow-security.yml` runs on
 `.github/workflows/codeql.yml` runs nightly on the default branch (`main`) via
 `schedule`, with `workflow_dispatch` kept for manual diagnostics; and
 `.github/workflows/codex-security.yml` runs on pushed `v*.*.*-pre.*` tags, and is
-also callable through `workflow_call` and `workflow_dispatch`. CodeQL does
-not run on `pull_request`, `merge_group`, or pushes to `main`, so it reports
+also callable through `workflow_call` and `workflow_dispatch`. CodeQL has no
+automatic `pull_request`, `merge_group`, or push trigger, so it reports
 repository-level Code Scanning state on the default branch instead of per-PR
 results, and its four-language matrix stays off the per-change critical path.
 Codex Security is release-scoped rather than change-scoped, so it never runs on
-a pull request or merge group.
+a pull request or merge group automatically.
+
+`.github/workflows/security-scan.yml` is a manual and reusable parent for Codex
+Security, CodeQL, Trivy, Cargo Deny, and Actionlint/Zizmor. Each child runs
+independently against the supplied pre-release tag; Codex retains its cumulative
+stable-to-candidate range. The parent forwards OCI references to Trivy and
+publishes SARIF, including Codex results on manual parent runs. Codex publishes
+against the candidate commit on `main`; the other SARIF producers use the
+candidate tag and commit. Cargo Deny retains its self-hosted runner and CI
+container. Dependency Review and Trivy Changes remain separate comparison
+workflows. Existing standalone triggers remain active.
+
+The parent enforces HIGH/CRITICAL findings for Codex, CodeQL, Trivy, and Zizmor.
+Its `allow-high-critical` input disables that threshold while keeping execution
+and publication failures fatal. Each scanner evaluates its existing report
+after publication. Actionlint stays informational; Cargo Deny runs its native
+advisory check, which is independent of the severity override. Standalone
+finding policies are unchanged. Child concurrency groups distinguish the
+scanner as well as the caller, so sibling workflows cannot cancel one another.
+Codex retains its repository-wide release qualification group.
+See [CI.md](../CI.md#run-the-security-scans-together) for invocation examples.
 
 - **Actionlint and Zizmor** analyze the workflow definitions themselves.
   Repository configuration lives in `.github/actionlint.yml` (self-hosted runner
@@ -372,8 +392,8 @@ a pull request or merge group.
   integration targets the cfg override does not reach. Examples remain in scope,
   and E2E test code stays excluded because `e2e/` is not an analyzed path. Only
   Go requires a build; the other languages use build mode `none`. Analysis runs
-  on the nightly schedule or by manual dispatch. Results are uploaded to Code
-  Scanning and always retained as workflow artifacts.
+  on the nightly schedule, by manual dispatch, or through `workflow_call`.
+  Results are uploaded to Code Scanning and always retained as workflow artifacts.
 - **Codex Security** qualifies release candidates rather than individual
   changes. The job installs a pinned `@openai/codex-security` release into the
   runner temp directory before the repository is checked out and invokes it by
@@ -439,7 +459,9 @@ a pull request or merge group.
   `CODEX_SECURITY_STATE_DIR`, where every shell command the agent ran is
   recorded. No command at all is the signal that the sandbox failed to start.
 
-Findings never fail these checks; scanner and build failures do. A scanner that
+Findings do not fail standalone informational runs; reusable callers can enable
+HIGH/CRITICAL enforcement with `fail-on-findings`. Scanner and build failures
+always fail. A scanner that
 cannot run, a CodeQL analyzer that does not complete, an unexpected Dependency
 Graph API error, and a Codex Security range, scan, or export failure are all
 errors, which keeps an informational check from silently degrading into a no-op.


### PR DESCRIPTION
## Summary

Add a manual and reusable `Security Scan` workflow that runs the existing security scanners in parallel against a pre-release candidate. HIGH/CRITICAL findings fail by default; `allow-high-critical` disables that threshold while scanner and report-publication errors remain fatal.

## Related Issue

No issue required: CI maintenance composing existing scanner workflows and documenting their invocation, without product runtime or public API changes.

## Changes

- Call Codex Security, CodeQL, Trivy, Cargo Deny, and Actionlint/Zizmor through `workflow_call`, with the same candidate tag and separate scanner concurrency groups.
- Gate Codex finding severities, CodeQL security scores >= 7.0, Trivy HIGH/CRITICAL findings (including unfixed vulnerabilities), and Zizmor High findings after report publication.
- Keep Actionlint informational. Run only `cargo deny check advisories` in the parent with its native failure behavior, independent of `allow-high-critical`.
- Preserve standalone triggers and defaults; document inputs, invocation examples, and failure behavior in `CI.md` and `architecture/build.md`.

## Testing

- [x] Actionlint passes for all six affected workflows.
- [x] Markdownlint passes; `git diff --check` passes.
- [x] Local checks of the actual workflow scripts cover MEDIUM/HIGH/CRITICAL classification, invalid CodeQL/Codex reports, and threshold override behavior.
- [ ] `mise run pre-commit` passes: attempted, but the license check fails on four existing, untracked `.cursor-tmp/zizmor-audit-*/base/.github/workflows/publish.yml` files outside this PR. `mise run ci` was also attempted and stops at the same check.
- [ ] Unit tests added/updated: not applicable; changes are workflow YAML and documentation.
- [ ] E2E tests added/updated: not applicable. The complete scanner workflow has not been run on GitHub.

## Checklist

- [x] Follows Conventional Commits.
- [x] Commits are signed off (DCO).
- [x] Architecture docs updated.
