### PR TITLE
fix(policy): normalize protocol names before OPA validation

### DIFF
--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -13,7 +13,7 @@ use openshell_core::policy::{
     FilesystemPolicy, LandlockCompatibility, LandlockPolicy, ProcessPolicy,
 };
 use openshell_core::proto::SandboxPolicy as ProtoSandboxPolicy;
-use openshell_policy::L7ConfigStanza;
+use openshell_policy::{L7ConfigStanza, L7Protocol as PolicyL7Protocol};
 use openshell_supervisor_middleware::{ChainEntry, ChainRunner, MiddlewareRegistry};
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -446,6 +446,7 @@ impl OpaEngine {
         let mut data: serde_json::Value = serde_json::from_str(&data_json_str)
             .map_err(|e| miette::miette!("internal: failed to parse proto JSON: {e}"))?;
         inject_runtime_policy_data(&mut data, require_binary_identity);
+        normalize_endpoint_protocols(&mut data);
 
         // Validate BEFORE expanding presets
         let (errors, warnings) = crate::l7::validate_l7_policies(&data);
@@ -1387,6 +1388,7 @@ fn preprocess_yaml_data(
     let mut data: serde_json::Value = serde_yml::from_str(yaml_str)
         .map_err(|e| miette::miette!("failed to parse YAML data: {e}"))?;
     inject_runtime_policy_data(&mut data, require_binary_identity);
+    normalize_endpoint_protocols(&mut data);
 
     // Normalize port → ports for all endpoints so Rego always sees "ports" array.
     normalize_endpoint_ports(&mut data);
@@ -1434,6 +1436,57 @@ fn preprocess_yaml_data(
     emit_l7_config_warnings(&expansion_warnings, "L7 access preset expansion warning");
 
     serde_json::to_string(&data).map_err(|e| miette::miette!("failed to serialize data: {e}"))
+}
+
+/// Canonicalize recognized protocol spellings before L7 validation or Rego use.
+///
+/// Rust parses protocol names case-insensitively, while Rego compares stable
+/// wire keys. Publishing one canonical spelling keeps rule validation, typed
+/// routing, and authorization on the same protocol branch.
+fn normalize_endpoint_protocols(data: &mut serde_json::Value) {
+    let Some(policies) = data
+        .get_mut("network_policies")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    for policy in policies.values_mut() {
+        let Some(endpoints) = policy
+            .get_mut("endpoints")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+
+        for endpoint in endpoints {
+            let Some(endpoint) = endpoint.as_object_mut() else {
+                continue;
+            };
+            let Some(protocol) = endpoint.get("protocol").and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            let canonical = if protocol.eq_ignore_ascii_case("tcp") {
+                Some("tcp")
+            } else {
+                PolicyL7Protocol::parse(protocol).map(|protocol| match protocol {
+                    PolicyL7Protocol::Rest => "rest",
+                    PolicyL7Protocol::Websocket => "websocket",
+                    PolicyL7Protocol::Graphql => "graphql",
+                    PolicyL7Protocol::Sql => "sql",
+                    PolicyL7Protocol::JsonRpc => "json-rpc",
+                    PolicyL7Protocol::Mcp => "mcp",
+                })
+            };
+            if let Some(canonical) = canonical {
+                endpoint.insert(
+                    "protocol".to_string(),
+                    serde_json::Value::String(canonical.to_string()),
+                );
+            }
+        }
+    }
 }
 
 /// Normalize endpoint port/ports in JSON data.
@@ -1547,6 +1600,9 @@ fn normalize_l7_config_alias(
     };
     if config.is_null() {
         ep.remove(key);
+        if stanza == L7ConfigStanza::Mcp {
+            errors.push(format!("{loc}.{key}: mcp config must be an object"));
+        }
         return;
     }
     match openshell_policy::l7_config_alias_runtime_fields(stanza, config) {
@@ -5057,7 +5113,55 @@ network_policies:
             .expect("expected MCP endpoint config");
         let l7 = crate::l7::parse_l7_config(&config).expect("parse L7 endpoint config");
 
+        let config_json: serde_json::Value = serde_json::from_str(
+            &config
+                .to_json_str()
+                .expect("endpoint config must serialize as JSON"),
+        )
+        .expect("endpoint config must be valid JSON");
+        assert_eq!(
+            config_json["protocol"],
+            serde_json::json!("mcp"),
+            "OPA data must use the canonical protocol key"
+        );
         assert_eq!(l7.mcp_versions, vec![DEFAULT_MCP_PROTOCOL_VERSION]);
+        assert!(eval_l7(
+            &engine,
+            &l7_jsonrpc_input("mcp.example.com", 443, "/", "tools/list")
+        ));
+        assert!(!eval_l7(
+            &engine,
+            &l7_jsonrpc_input("mcp.example.com", 443, "/", "tools/call")
+        ));
+    }
+
+    #[test]
+    fn yaml_load_rejects_rest_shaped_rules_on_mixed_case_mcp_protocol() {
+        let data = r#"
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        protocol: MCP
+        rules:
+          - allow:
+              method: POST
+              path: "**"
+    binaries:
+      - { path: /usr/bin/curl }
+"#;
+
+        let Err(error) = OpaEngine::from_strings(TEST_POLICY, data) else {
+            panic!("mixed-case MCP must not bypass MCP rule validation");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("mcp L7 rules must use method/tool, not path/query"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -5126,6 +5230,40 @@ network_policies:
                 .contains("mcp.versions and mcp_versions cannot both be set"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn yaml_load_rejects_null_mcp_config_before_defaulting() {
+        for mcp_fields in [
+            "mcp: null",
+            "mcp: null\n        mcp_versions: [\"2025-11-25\"]",
+        ] {
+            let data = format!(
+                r#"
+network_policies:
+  mcp:
+    name: mcp
+    endpoints:
+      - host: mcp.example.com
+        port: 443
+        protocol: mcp
+        {mcp_fields}
+        rules:
+          - allow:
+              method: tools/list
+    binaries:
+      - {{ path: /usr/bin/curl }}
+"#
+            );
+
+            let Err(error) = OpaEngine::from_strings(TEST_POLICY, &data) else {
+                panic!("null MCP config must reject activation");
+            };
+            assert!(
+                error.to_string().contains("mcp config must be an object"),
+                "{error}"
+            );
+        }
     }
 
     #[test]
@@ -5607,6 +5745,13 @@ network_policies:
                 .query_endpoint_config(&input)
                 .expect("query endpoint config")
                 .expect("expected MCP endpoint config");
+            let config_json: serde_json::Value = serde_json::from_str(
+                &config
+                    .to_json_str()
+                    .expect("endpoint config must serialize as JSON"),
+            )
+            .expect("endpoint config must be valid JSON");
+            assert_eq!(config_json["protocol"], serde_json::json!("mcp"));
             let l7 = crate::l7::parse_l7_config(&config).expect("parse L7 endpoint config");
             assert_eq!(
                 l7.mcp_versions,

--- a/crates/openshell-supervisor-network/src/opa.rs
+++ b/crates/openshell-supervisor-network/src/opa.rs
@@ -5082,6 +5082,199 @@ network_policies:
         );
     }
 
+    const PROTOCOL_NAME_CASES: [(&str, &str); 7] = [
+        ("tcp", "TcP"),
+        ("rest", "ReSt"),
+        ("websocket", "WeBsOcKeT"),
+        ("graphql", "GrApHqL"),
+        ("sql", "SqL"),
+        ("json-rpc", "JsOn-RpC"),
+        ("mcp", "McP"),
+    ];
+
+    fn assert_loaded_protocol_name(engine: &OpaEngine, authored: &str, canonical: &str) {
+        // Inspect stored data before typed parsing, which accepts mixed case and
+        // would otherwise hide a missing normalization step in either loader.
+        let data = engine.engine.lock().expect("OPA engine lock").get_data();
+        assert_eq!(
+            data["network_policies"]["protocol_names"]["endpoints"][0]["protocol"],
+            regorus::Value::from(canonical),
+            "stored protocol for {authored}"
+        );
+
+        let input = NetworkInput {
+            host: "protocol.example.com".into(),
+            port: 443,
+            binary_path: PathBuf::from("/usr/bin/curl"),
+            binary_sha256: "unused".into(),
+            ancestors: vec![],
+            cmdline_paths: vec![],
+        };
+        let config = engine
+            .query_endpoint_config(&input)
+            .expect("endpoint query");
+        if canonical == "tcp" {
+            // TCP remains an L4 endpoint; canonical spelling must not opt it
+            // into request inspection or change its network-level allowance.
+            assert!(config.is_none(), "TCP must not return L7 configuration");
+            assert!(matches!(
+                engine
+                    .evaluate_network_action(&input)
+                    .expect("network query"),
+                NetworkAction::Allow { .. }
+            ));
+        } else {
+            let config = config.expect("L7 endpoint configuration");
+            assert_eq!(
+                config["protocol"],
+                regorus::Value::from(canonical),
+                "published endpoint protocol for {authored}"
+            );
+            crate::l7::parse_l7_config(&config).expect("valid typed L7 configuration");
+        }
+    }
+
+    #[test]
+    fn protocol_names_yaml_load_canonicalizes_all_supported_values() {
+        for (canonical, mixed_case) in PROTOCOL_NAME_CASES {
+            let fields = match canonical {
+                "tcp" => "",
+                "rest" | "websocket" => {
+                    "enforcement: enforce\n        rules: [{allow: {method: GET, path: /status}}]"
+                }
+                "graphql" => {
+                    "enforcement: enforce\n        rules: [{allow: {operation_type: query, fields: [viewer]}}]"
+                }
+                // SQL inspection supports audit mode, not enforce mode.
+                "sql" => "enforcement: audit\n        rules: [{allow: {command: SELECT}}]",
+                "json-rpc" => "enforcement: enforce\n        rules: [{allow: {method: status}}]",
+                "mcp" => "enforcement: enforce\n        rules: [{allow: {method: tools/list}}]",
+                _ => unreachable!("fixture must name a supported protocol"),
+            };
+            for authored in [
+                canonical.to_string(),
+                canonical.to_ascii_uppercase(),
+                mixed_case.into(),
+            ] {
+                let yaml = format!(
+                    r#"
+network_policies:
+  protocol_names:
+    name: protocol_names
+    endpoints:
+      - host: protocol.example.com
+        port: 443
+        protocol: {authored}
+        {fields}
+    binaries:
+      - {{ path: /usr/bin/curl }}
+"#
+                );
+                let engine = OpaEngine::from_strings(TEST_POLICY, &yaml)
+                    .unwrap_or_else(|error| panic!("valid YAML protocol {authored}: {error}"));
+                assert_loaded_protocol_name(&engine, &authored, canonical);
+            }
+        }
+    }
+
+    #[test]
+    fn protocol_names_proto_load_canonicalizes_all_supported_values() {
+        for (canonical, mixed_case) in PROTOCOL_NAME_CASES {
+            let allow = match canonical {
+                "tcp" => None,
+                "rest" | "websocket" => Some(L7Allow {
+                    method: "GET".into(),
+                    path: "/status".into(),
+                    ..Default::default()
+                }),
+                "graphql" => Some(L7Allow {
+                    operation_type: "query".into(),
+                    fields: vec!["viewer".into()],
+                    ..Default::default()
+                }),
+                "sql" => Some(L7Allow {
+                    command: "SELECT".into(),
+                    ..Default::default()
+                }),
+                "json-rpc" | "mcp" => Some(L7Allow {
+                    method: if canonical == "mcp" {
+                        "tools/list"
+                    } else {
+                        "status"
+                    }
+                    .into(),
+                    ..Default::default()
+                }),
+                _ => unreachable!("fixture must name a supported protocol"),
+            };
+            for authored in [
+                canonical.to_string(),
+                canonical.to_ascii_uppercase(),
+                mixed_case.into(),
+            ] {
+                let mut policy = openshell_policy::restrictive_default_policy();
+                policy.network_policies.insert(
+                    "protocol_names".into(),
+                    NetworkPolicyRule {
+                        name: "protocol_names".into(),
+                        endpoints: vec![NetworkEndpoint {
+                            host: "protocol.example.com".into(),
+                            port: 443,
+                            protocol: authored.clone(),
+                            // TCP has no L7 settings; SQL only supports audit.
+                            enforcement: match canonical {
+                                "tcp" => "",
+                                "sql" => "audit",
+                                _ => "enforce",
+                            }
+                            .into(),
+                            rules: allow
+                                .clone()
+                                .map(|allow| L7Rule { allow: Some(allow) })
+                                .into_iter()
+                                .collect(),
+                            ..Default::default()
+                        }],
+                        binaries: vec![NetworkBinary {
+                            path: "/usr/bin/curl".into(),
+                            ..Default::default()
+                        }],
+                    },
+                );
+                let engine = OpaEngine::from_proto(&policy)
+                    .unwrap_or_else(|error| panic!("valid protobuf protocol {authored}: {error}"));
+                assert_loaded_protocol_name(&engine, &authored, canonical);
+            }
+        }
+    }
+
+    #[test]
+    fn protocol_names_normalization_preserves_other_data_and_is_idempotent() {
+        let mut data = serde_json::json!({
+            "network_policies": {
+                "first": {
+                    "endpoints": [
+                        {"protocol": "ReSt", "path": "/KeepCase", "host": "KeepCase.example"},
+                        {"protocol": "FutureProtocol"},
+                        {"protocol": ""},
+                        {"protocol": null},
+                        {"protocol": 42},
+                        {"host": "no-protocol.example"}
+                    ]
+                },
+                "second": {"endpoints": [{"protocol": "JsOn-RpC"}]}
+            }
+        });
+        let mut expected = data.clone();
+        expected["network_policies"]["first"]["endpoints"][0]["protocol"] = "rest".into();
+        expected["network_policies"]["second"]["endpoints"][0]["protocol"] = "json-rpc".into();
+
+        normalize_endpoint_protocols(&mut data);
+        assert_eq!(data, expected, "only recognized protocol names may change");
+        normalize_endpoint_protocols(&mut data);
+        assert_eq!(data, expected, "normalization must be idempotent");
+    }
+
     #[test]
     fn yaml_load_accepts_mixed_case_mcp_protocol_with_default_versions() {
         let data = r#"


### PR DESCRIPTION
## Summary

Rust accepts protocol names without regard to case, but OPA can retain their original spelling. This PR normalizes every supported protocol name before validation and rule evaluation so Rust and Rego use the same name.

This supersedes #3251 because its fork branch does not allow maintainer edits. It preserves the original two commits by @shiju-nv and rebases them onto current `main`, which includes the canonical-process exit reconciliation needed by the E2E suite.

## Related Issue

Related to #3092

## Changes

- Normalize `tcp`, `rest`, `websocket`, `graphql`, `sql`, `json-rpc`, and `mcp` in both YAML and protobuf policy loading. Unknown names remain subject to existing validation.
- Test lowercase, uppercase, and mixed-case spellings for every supported protocol. Check the raw name stored in OPA and the name returned in L7 endpoint configuration. TCP remains L4-only.
- Check that normalization leaves unrelated fields and unrecognized values unchanged, and that applying it twice produces the same result.
- Reject explicit `mcp: null` while preserving defaults for omitted MCP configuration.
- Rebase onto current `main` to incorporate #3204, which fixes the provisional container-exit race that failed the original PR E2E run.

## Testing

- [x] `mise run pre-commit` passes
- [x] `cargo test -p openshell-supervisor-network`
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (not applicable; existing E2E suite will be run)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (not applicable; published policy docs already define canonical spellings and reject null MCP configuration)