### PR TITLE
fix(build): honor Cargo target directory when staging binaries

### DIFF
--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -171,6 +171,7 @@ build_component_for_arch() {
   local current_host_os
   local current_host_arch
   local binary_path
+  local cargo_output_dir
   local build_rustflags
 
   resolve_component "$component"
@@ -257,7 +258,8 @@ build_component_for_arch() {
     CARGO_INCREMENTAL=0 mise x -- ${cargo_env[@]+"${cargo_env[@]}"} "${cargo_subcommand[@]}" "${args[@]}"
   )
 
-  binary_path="${ROOT}/target/${target}/release/${binary}"
+  cargo_output_dir="$(cd "$ROOT" && mise x -- cargo metadata --format-version=1 --no-deps | jq -er '.target_directory')"
+  binary_path="${cargo_output_dir}/${target}/release/${binary}"
   if [[ "$component" == "gateway" ]]; then
     "$SCRIPT_DIR/verify-glibc-symbols.sh" 2.28 "$binary_path"
   elif [[ "$component" == "supervisor" ]]; then


### PR DESCRIPTION
## Summary

Stage gateway and supervisor binaries from Cargo's configured output directory. Builds using `CARGO_TARGET_DIR` or `build.target-dir` can succeed while staging looks in the default `target/` directory and fails or copies a stale binary.

## Context

This is a latent local-build bug rather than a response to a CI or production failure. The default Cargo output directory is `<workspace>/target`, so the hard-coded staging path works for ordinary builds. Release CI does not exercise this script; it downloads and stages prebuilt artifacts directly.

The mismatch appears when a local Docker or Skaffold build uses a custom Cargo target directory:

1. Cargo writes the newly built binary under the configured target directory.
2. The staging script looks under `<workspace>/target` instead.
3. If the default path has no binary, verification or staging fails after the build succeeds.
4. If the default path contains an older binary, staging can succeed while copying that stale binary into the image. A smoke test may then exercise old code instead of the current checkout.

The issue surfaced in #3074 when its content-guard smoke workflow began building the Linux supervisor image through this staging path while supporting `CARGO_TARGET_DIR`. It was split into this PR because the build fix is independent of the middleware feature.

## Related Issue

No issue required: this is an obvious localized build-script bug fix extracted from #3074.

## Changes

- Read `target_directory` from `cargo metadata` in the same workspace and mise environment as the build.
- Use that directory when locating the release binary for verification and staging.

## Testing

- [x] `mise run pre-commit` passes through the commit hook.
- [x] `bash -n tasks/scripts/stage-prebuilt-binaries.sh` and `git diff --check` pass.
- [x] Ran the staging script in a disposable fixture with stubbed Cargo builds and metadata. Checked the default output directory, a custom path containing spaces with a stale binary in the default directory, and missing metadata. The first two stage the expected binary; missing metadata fails without staging.
- Full gateway/supervisor image builds were not rerun for this path lookup change.

## Checklist

- [x] Follows Conventional Commits.
- [x] Commit is signed off for DCO.
- Architecture docs are unchanged; component boundaries and runtime behavior are unchanged.
