### PR TITLE
refactor(ocsf): rename SandboxContext to EventContext

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ ocsf_emit!(event);
 
 ### Key points
 
-- `crate::ocsf_ctx()` returns the process-wide `SandboxContext`. It is always available (falls back to defaults in tests).
+- `crate::ocsf_ctx()` returns the process-wide `EventContext`. It is always available (falls back to defaults in tests).
 - `ocsf_emit!()` is non-blocking and cannot panic. It stores the event in a thread-local and emits via `tracing::info!()`.
 - The shorthand layer and JSONL layer extract the event from the thread-local. The shorthand format is derived automatically from the builder fields.
 - For security findings, **dual-emit**: one domain event (e.g., `SshActivityBuilder`) AND one `DetectionFindingBuilder` for the same incident.

--- a/crates/openshell-ocsf/src/builders/api_activity.rs
+++ b/crates/openshell-ocsf/src/builders/api_activity.rs
@@ -3,7 +3,7 @@
 
 //! Builder for API Activity [6003] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{ApiActivityEvent, OcsfEvent};
@@ -26,7 +26,7 @@ fn sanitize_model_name(name: &str) -> String {
 
 /// Builder for API Activity [6003] events.
 pub struct ApiActivityBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     severity: SeverityId,
     status: Option<StatusId>,
     message: Option<String>,
@@ -39,7 +39,7 @@ pub struct ApiActivityBuilder<'a> {
 
 impl<'a> ApiActivityBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext, operation: impl Into<String>) -> Self {
+    pub fn new(ctx: &'a EventContext, operation: impl Into<String>) -> Self {
         Self {
             ctx,
             severity: SeverityId::Informational,

--- a/crates/openshell-ocsf/src/builders/base.rs
+++ b/crates/openshell-ocsf/src/builders/base.rs
@@ -3,14 +3,14 @@
 
 //! Builder for Base Event [0].
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{BaseEvent, OcsfEvent};
 
 /// Builder for Base Event [0] — events without a specific OCSF class.
 pub struct BaseEventBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     severity: SeverityId,
     status: Option<StatusId>,
     message: Option<String>,
@@ -20,7 +20,7 @@ pub struct BaseEventBuilder<'a> {
 
 impl<'a> BaseEventBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             severity: SeverityId::Informational,

--- a/crates/openshell-ocsf/src/builders/config.rs
+++ b/crates/openshell-ocsf/src/builders/config.rs
@@ -3,14 +3,14 @@
 
 //! Builder for Device Config State Change [5019] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{SecurityLevelId, SeverityId, StateId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{DeviceConfigStateChangeEvent, OcsfEvent};
 
 /// Builder for Device Config State Change [5019] events.
 pub struct ConfigStateChangeBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     severity: SeverityId,
     status: Option<StatusId>,
     state_id: Option<StateId>,
@@ -23,7 +23,7 @@ pub struct ConfigStateChangeBuilder<'a> {
 
 impl<'a> ConfigStateChangeBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             severity: SeverityId::Informational,

--- a/crates/openshell-ocsf/src/builders/finding.rs
+++ b/crates/openshell-ocsf/src/builders/finding.rs
@@ -3,7 +3,7 @@
 
 //! Builder for Detection Finding [2004] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActionId, ActivityId, ConfidenceId, DispositionId, RiskLevelId, SeverityId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{DetectionFindingEvent, OcsfEvent};
@@ -11,7 +11,7 @@ use crate::objects::{Attack, Evidence, FindingInfo, Remediation};
 
 /// Builder for Detection Finding [2004] events.
 pub struct DetectionFindingBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     severity: SeverityId,
     action: Option<ActionId>,
@@ -30,7 +30,7 @@ pub struct DetectionFindingBuilder<'a> {
 
 impl<'a> DetectionFindingBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Open,

--- a/crates/openshell-ocsf/src/builders/http.rs
+++ b/crates/openshell-ocsf/src/builders/http.rs
@@ -3,7 +3,7 @@
 
 //! Builder for HTTP Activity [4002] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActionId, ActivityId, DispositionId, SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{HttpActivityEvent, OcsfEvent};
@@ -11,7 +11,7 @@ use crate::objects::{Actor, Endpoint, FirewallRule, HttpRequest, HttpResponse};
 
 /// Builder for HTTP Activity [4002] events.
 pub struct HttpActivityBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     action: Option<ActionId>,
     disposition: Option<DispositionId>,
@@ -30,7 +30,7 @@ pub struct HttpActivityBuilder<'a> {
 
 impl<'a> HttpActivityBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Unknown,

--- a/crates/openshell-ocsf/src/builders/lifecycle.rs
+++ b/crates/openshell-ocsf/src/builders/lifecycle.rs
@@ -3,7 +3,7 @@
 
 //! Builder for Application Lifecycle [6002] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActivityId, SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{ApplicationLifecycleEvent, OcsfEvent};
@@ -11,7 +11,7 @@ use crate::objects::Product;
 
 /// Builder for Application Lifecycle [6002] events.
 pub struct AppLifecycleBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     severity: SeverityId,
     status: Option<StatusId>,
@@ -20,7 +20,7 @@ pub struct AppLifecycleBuilder<'a> {
 
 impl<'a> AppLifecycleBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Unknown,

--- a/crates/openshell-ocsf/src/builders/mod.rs
+++ b/crates/openshell-ocsf/src/builders/mod.rs
@@ -3,7 +3,7 @@
 
 //! Ergonomic builders for constructing OCSF events.
 //!
-//! Each event class has a builder that takes a `SandboxContext` reference
+//! Each event class has a builder that takes a `EventContext` reference
 //! and provides chainable methods for setting event fields.
 
 /// Generate the shared `severity`, `status`, and `message` setter methods that
@@ -180,7 +180,7 @@ use crate::objects::{Container, Device, Endpoint, Image, Metadata, Product};
 /// Passed to every event builder to populate shared OCSF fields
 /// (metadata, container, device, proxy endpoint).
 #[derive(Debug, Clone)]
-pub struct SandboxContext {
+pub struct EventContext {
     /// Sandbox unique identifier.
     pub sandbox_id: String,
     /// Sandbox display name.
@@ -197,7 +197,7 @@ pub struct SandboxContext {
     pub proxy_port: u16,
 }
 
-impl SandboxContext {
+impl EventContext {
     /// Build the OCSF `Metadata` object for any event.
     #[must_use]
     pub fn metadata(&self, profiles: &[&str]) -> Metadata {
@@ -259,8 +259,8 @@ impl SandboxContext {
 }
 
 #[cfg(test)]
-pub(crate) fn test_sandbox_context() -> SandboxContext {
-    SandboxContext {
+pub(crate) fn test_sandbox_context() -> EventContext {
+    EventContext {
         sandbox_id: "sandbox-abc123".to_string(),
         sandbox_name: "my-sandbox".to_string(),
         container_image: "ghcr.io/openshell/sandbox:latest".to_string(),

--- a/crates/openshell-ocsf/src/builders/network.rs
+++ b/crates/openshell-ocsf/src/builders/network.rs
@@ -3,7 +3,7 @@
 
 //! Builder for Network Activity [4001] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActionId, ActivityId, DispositionId, SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{NetworkActivityEvent, OcsfEvent};
@@ -11,7 +11,7 @@ use crate::objects::{Actor, ConnectionInfo, Endpoint, FirewallRule};
 
 /// Builder for Network Activity [4001] events.
 pub struct NetworkActivityBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     activity_name: Option<String>,
     action: Option<ActionId>,
@@ -33,7 +33,7 @@ pub struct NetworkActivityBuilder<'a> {
 impl<'a> NetworkActivityBuilder<'a> {
     /// Start building a Network Activity event.
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Unknown,

--- a/crates/openshell-ocsf/src/builders/process.rs
+++ b/crates/openshell-ocsf/src/builders/process.rs
@@ -3,7 +3,7 @@
 
 //! Builder for Process Activity [1007] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActionId, ActivityId, DispositionId, LaunchTypeId, SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{OcsfEvent, ProcessActivityEvent};
@@ -11,7 +11,7 @@ use crate::objects::{Actor, Process};
 
 /// Builder for Process Activity [1007] events.
 pub struct ProcessActivityBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     severity: SeverityId,
     status: Option<StatusId>,
@@ -26,7 +26,7 @@ pub struct ProcessActivityBuilder<'a> {
 
 impl<'a> ProcessActivityBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Unknown,

--- a/crates/openshell-ocsf/src/builders/ssh.rs
+++ b/crates/openshell-ocsf/src/builders/ssh.rs
@@ -3,7 +3,7 @@
 
 //! Builder for SSH Activity [4007] events.
 
-use crate::builders::SandboxContext;
+use crate::builders::EventContext;
 use crate::enums::{ActionId, ActivityId, AuthTypeId, DispositionId, SeverityId, StatusId};
 use crate::events::base_event::BaseEventData;
 use crate::events::{OcsfEvent, SshActivityEvent};
@@ -11,7 +11,7 @@ use crate::objects::{Actor, Endpoint};
 
 /// Builder for SSH Activity [4007] events.
 pub struct SshActivityBuilder<'a> {
-    ctx: &'a SandboxContext,
+    ctx: &'a EventContext,
     activity: ActivityId,
     action: Option<ActionId>,
     disposition: Option<DispositionId>,
@@ -28,7 +28,7 @@ pub struct SshActivityBuilder<'a> {
 
 impl<'a> SshActivityBuilder<'a> {
     #[must_use]
-    pub fn new(ctx: &'a SandboxContext) -> Self {
+    pub fn new(ctx: &'a EventContext) -> Self {
         Self {
             ctx,
             activity: ActivityId::Unknown,

--- a/crates/openshell-ocsf/src/ctx.rs
+++ b/crates/openshell-ocsf/src/ctx.rs
@@ -1,19 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Process-wide [`SandboxContext`] singleton.
+//! Process-wide [`EventContext`] singleton.
 //!
 //! Initialised once via [`set_ctx`] during sandbox start; read by every event
 //! builder via [`ctx`]. Falls back to a default context when the singleton has
 //! not been set (e.g. unit tests that exercise builders without booting the
 //! sandbox).
 
-use crate::SandboxContext;
+use crate::EventContext;
 use std::sync::{LazyLock, OnceLock};
 
-static OCSF_CTX: OnceLock<SandboxContext> = OnceLock::new();
+static OCSF_CTX: OnceLock<EventContext> = OnceLock::new();
 
-static OCSF_CTX_FALLBACK: LazyLock<SandboxContext> = LazyLock::new(|| SandboxContext {
+static OCSF_CTX_FALLBACK: LazyLock<EventContext> = LazyLock::new(|| EventContext {
     sandbox_id: String::new(),
     sandbox_name: String::new(),
     container_image: String::new(),
@@ -27,15 +27,15 @@ static OCSF_CTX_FALLBACK: LazyLock<SandboxContext> = LazyLock::new(|| SandboxCon
 ///
 /// Returns `false` if the context was already set; the caller may log and
 /// continue. Intended to be called exactly once during sandbox startup.
-pub fn set_ctx(ctx: SandboxContext) -> bool {
+pub fn set_ctx(ctx: EventContext) -> bool {
     OCSF_CTX.set(ctx).is_ok()
 }
 
-/// Return a reference to the process-wide [`SandboxContext`].
+/// Return a reference to the process-wide [`EventContext`].
 ///
 /// Falls back to a default context if [`set_ctx`] has not been called (e.g.
 /// during unit tests that exercise individual builders).
 #[must_use]
-pub fn ctx() -> &'static SandboxContext {
+pub fn ctx() -> &'static EventContext {
     OCSF_CTX.get().unwrap_or(&OCSF_CTX_FALLBACK)
 }

--- a/crates/openshell-ocsf/src/lib.rs
+++ b/crates/openshell-ocsf/src/lib.rs
@@ -12,7 +12,7 @@
 //!   State Change, and Base Event
 //! - **Typed enums and objects**: All OCSF enum and object types used by the
 //!   event classes
-//! - **Builders**: Ergonomic per-class builders with `SandboxContext` for shared
+//! - **Builders**: Ergonomic per-class builders with `EventContext` for shared
 //!   metadata
 //! - **Dual formatters**: `format_shorthand()` for human-readable single-line
 //!   output, and `to_json()`/`to_json_line()` for OCSF-compliant JSONL
@@ -58,8 +58,8 @@ pub use objects::{
 // --- Builders ---
 pub use builders::{
     ApiActivityBuilder, AppLifecycleBuilder, BaseEventBuilder, ConfigStateChangeBuilder,
-    DetectionFindingBuilder, HttpActivityBuilder, NetworkActivityBuilder, ProcessActivityBuilder,
-    SandboxContext, SshActivityBuilder,
+    DetectionFindingBuilder, EventContext, HttpActivityBuilder, NetworkActivityBuilder,
+    ProcessActivityBuilder, SshActivityBuilder,
 };
 
 // --- Tracing layers ---

--- a/crates/openshell-ocsf/tests/event_identity.rs
+++ b/crates/openshell-ocsf/tests/event_identity.rs
@@ -5,10 +5,10 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use openshell_ocsf::{ActivityId, NetworkActivityBuilder, OcsfEvent, SandboxContext, SeverityId};
+use openshell_ocsf::{ActivityId, EventContext, NetworkActivityBuilder, OcsfEvent, SeverityId};
 
-fn sandbox_ctx(container_image: &str) -> SandboxContext {
-    SandboxContext {
+fn sandbox_ctx(container_image: &str) -> EventContext {
+    EventContext {
         sandbox_id: "sb-1".to_string(),
         sandbox_name: "agent-01".to_string(),
         container_image: container_image.to_string(),
@@ -19,7 +19,7 @@ fn sandbox_ctx(container_image: &str) -> SandboxContext {
     }
 }
 
-fn event(ctx: &SandboxContext) -> OcsfEvent {
+fn event(ctx: &EventContext) -> OcsfEvent {
     NetworkActivityBuilder::new(ctx)
         .activity(ActivityId::Open)
         .severity(SeverityId::Medium)

--- a/crates/openshell-ocsf/tests/roundtrip.rs
+++ b/crates/openshell-ocsf/tests/roundtrip.rs
@@ -12,14 +12,14 @@ use std::net::{IpAddr, Ipv4Addr};
 use openshell_ocsf::{
     ActionId, ActivityId, AiModel, ApiActivityBuilder, AppLifecycleBuilder, Attack, AuthTypeId,
     BaseEventBuilder, ConfidenceId, ConfigStateChangeBuilder, ConnectionInfo,
-    DetectionFindingBuilder, DispositionId, Endpoint, FindingInfo, HttpActivityBuilder, HttpMethod,
-    HttpRequest, HttpResponse, LaunchTypeId, NetworkActivityBuilder, OcsfEvent, Process,
-    ProcessActivityBuilder, RiskLevelId, SandboxContext, SecurityLevelId, SeverityId,
-    SshActivityBuilder, StateId, StatusId, Url,
+    DetectionFindingBuilder, DispositionId, Endpoint, EventContext, FindingInfo,
+    HttpActivityBuilder, HttpMethod, HttpRequest, HttpResponse, LaunchTypeId,
+    NetworkActivityBuilder, OcsfEvent, Process, ProcessActivityBuilder, RiskLevelId,
+    SecurityLevelId, SeverityId, SshActivityBuilder, StateId, StatusId, Url,
 };
 
-fn ctx() -> SandboxContext {
-    SandboxContext {
+fn ctx() -> EventContext {
+    EventContext {
         sandbox_id: "sb-7f3a9c2e14b8".to_string(),
         sandbox_name: "agent-workspace-01".to_string(),
         container_image: "ghcr.io/nvidia/openshell-community/sandboxes/base:latest".to_string(),

--- a/crates/openshell-sandbox/src/lib.rs
+++ b/crates/openshell-sandbox/src/lib.rs
@@ -38,7 +38,7 @@ use openshell_core::PolicyValidationFailureMode;
 
 use openshell_ocsf::{
     ActionId, ActivityId, AppLifecycleBuilder, ConfidenceId, ConfigStateChangeBuilder,
-    DetectionFindingBuilder, DispositionId, FindingInfo, OcsfEvent, SandboxContext, SeverityId,
+    DetectionFindingBuilder, DispositionId, EventContext, FindingInfo, OcsfEvent, SeverityId,
     StateId, StatusId, ocsf_emit,
 };
 
@@ -142,7 +142,7 @@ pub async fn run_sandbox(
             |s| s.trim().to_string(),
         );
 
-        if !openshell_ocsf::ctx::set_ctx(SandboxContext {
+        if !openshell_ocsf::ctx::set_ctx(EventContext {
             sandbox_id: sandbox_id.clone().unwrap_or_default(),
             sandbox_name: sandbox.as_deref().unwrap_or_default().to_string(),
             container_image: std::env::var("OPENSHELL_CONTAINER_IMAGE").unwrap_or_default(),

--- a/crates/openshell-server/src/grpc/policy.rs
+++ b/crates/openshell-server/src/grpc/policy.rs
@@ -60,7 +60,7 @@ use openshell_core::{
     settings::{self, SettingValueKind},
 };
 use openshell_ocsf::{
-    ConfigStateChangeBuilder, OCSF_TARGET, OcsfEvent, SandboxContext, SeverityId, StateId, StatusId,
+    ConfigStateChangeBuilder, EventContext, OCSF_TARGET, OcsfEvent, SeverityId, StateId, StatusId,
 };
 use openshell_policy::{
     PolicyMergeOp, ProviderPolicyLayer, canonicalize_advisor_add_rule, compose_effective_policy,
@@ -234,7 +234,7 @@ fn build_gateway_policy_audit_message(
     policy_hash: &str,
     extra_fields: &[(&str, String)],
 ) -> String {
-    let ctx = SandboxContext {
+    let ctx = EventContext {
         sandbox_id: sandbox_id.to_string(),
         sandbox_name: sandbox_name.to_string(),
         container_image: "openshell/gateway".to_string(),

--- a/crates/openshell-server/src/service_routing.rs
+++ b/crates/openshell-server/src/service_routing.rs
@@ -13,9 +13,9 @@ use openshell_core::config::ServiceRoutingConfig;
 use openshell_core::proto::{Sandbox, SandboxPhase, ServiceEndpoint, TcpRelayTarget, relay_open};
 use openshell_core::{ObjectId, VERSION};
 use openshell_ocsf::{
-    ActionId, ActivityId, ConfigStateChangeBuilder, DispositionId, Endpoint, HttpActivityBuilder,
-    HttpRequest, HttpResponse as OcsfHttpResponse, NetworkActivityBuilder, OCSF_TARGET, OcsfEvent,
-    SandboxContext, SeverityId, StateId, StatusId, Url as OcsfUrl,
+    ActionId, ActivityId, ConfigStateChangeBuilder, DispositionId, Endpoint, EventContext,
+    HttpActivityBuilder, HttpRequest, HttpResponse as OcsfHttpResponse, NetworkActivityBuilder,
+    OCSF_TARGET, OcsfEvent, SeverityId, StateId, StatusId, Url as OcsfUrl,
 };
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -760,8 +760,8 @@ fn emit_gateway_ocsf_event(sandbox_id: &str, event: OcsfEvent) {
     );
 }
 
-fn gateway_ocsf_ctx(sandbox_id: &str, sandbox_name: &str) -> SandboxContext {
-    SandboxContext {
+fn gateway_ocsf_ctx(sandbox_id: &str, sandbox_name: &str) -> EventContext {
+    EventContext {
         sandbox_id: sandbox_id.to_string(),
         sandbox_name: sandbox_name.to_string(),
         container_image: "openshell/gateway".to_string(),

--- a/crates/openshell-server/src/tls.rs
+++ b/crates/openshell-server/src/tls.rs
@@ -15,7 +15,7 @@ use notify::event::EventKind;
 use notify::{Event, RecursiveMode, Watcher};
 use openshell_core::{Error, Result};
 use openshell_ocsf::{
-    ConfigStateChangeBuilder, OCSF_TARGET, SandboxContext, SeverityId, StateId, StatusId,
+    ConfigStateChangeBuilder, EventContext, OCSF_TARGET, SeverityId, StateId, StatusId,
 };
 use rustls::ServerConfig;
 use rustls::crypto::aws_lc_rs::sign;
@@ -473,8 +473,8 @@ fn load_key(path: &Path) -> Result<PrivateKeyDer<'static>> {
 }
 
 /// Build an OCSF context for gateway-level (non-sandbox) events.
-fn tls_ocsf_ctx() -> SandboxContext {
-    SandboxContext {
+fn tls_ocsf_ctx() -> EventContext {
+    EventContext {
         sandbox_id: String::new(),
         sandbox_name: String::new(),
         container_image: "openshell/gateway".to_string(),

--- a/crates/openshell-supervisor-network/src/l7/middleware.rs
+++ b/crates/openshell-supervisor-network/src/l7/middleware.rs
@@ -611,7 +611,7 @@ pub async fn send_middleware_admission_exhausted_response<
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn middleware_request_input(
-    sandbox: &openshell_ocsf::SandboxContext,
+    sandbox: &openshell_ocsf::EventContext,
     scheme: &str,
     req: &crate::l7::provider::L7Request,
     ctx: &L7EvalContext,
@@ -1087,7 +1087,7 @@ mod tests {
 
     #[test]
     fn middleware_input_carries_real_sandbox_name() {
-        let sandbox = openshell_ocsf::SandboxContext {
+        let sandbox = openshell_ocsf::EventContext {
             sandbox_id: "sbx-123".into(),
             sandbox_name: "nightly-build".into(),
             container_image: String::new(),

--- a/crates/openshell-supervisor-network/src/l7/relay.rs
+++ b/crates/openshell-supervisor-network/src/l7/relay.rs
@@ -1149,10 +1149,10 @@ pub(crate) async fn websocket_middleware_preflight(
 
 /// Build the WebSocket preflight input from the sandbox and evaluation
 /// contexts. Kept separate from `websocket_middleware_preflight` (and taking an
-/// explicit `SandboxContext`) so the identifier copy is unit-testable with a
+/// explicit `EventContext`) so the identifier copy is unit-testable with a
 /// real sandbox name, mirroring `middleware_request_input` on the HTTP path.
 fn websocket_preflight_input(
-    sandbox: &openshell_ocsf::SandboxContext,
+    sandbox: &openshell_ocsf::EventContext,
     ctx: &L7EvalContext,
     req: &crate::l7::provider::L7Request,
     scheme: &str,
@@ -3022,7 +3022,7 @@ mod tests {
 
     #[test]
     fn websocket_preflight_input_carries_real_sandbox_name() {
-        let sandbox = openshell_ocsf::SandboxContext {
+        let sandbox = openshell_ocsf::EventContext {
             sandbox_id: "sbx-123".into(),
             sandbox_name: "nightly-build".into(),
             container_image: String::new(),

--- a/crates/openshell-supervisor-process/src/log_push.rs
+++ b/crates/openshell-supervisor-process/src/log_push.rs
@@ -317,13 +317,13 @@ impl tracing::field::Visit for LogVisitor {
 mod tests {
     use super::*;
     use openshell_ocsf::{
-        ActionId, ActivityId, DispositionId, Endpoint, NetworkActivityBuilder, SandboxContext,
+        ActionId, ActivityId, DispositionId, Endpoint, EventContext, NetworkActivityBuilder,
         SeverityId, StatusId, ocsf_emit,
     };
     use tracing_subscriber::layer::SubscriberExt;
 
-    fn ocsf_ctx() -> SandboxContext {
-        SandboxContext {
+    fn ocsf_ctx() -> EventContext {
+        EventContext {
             sandbox_id: "sb-test".to_string(),
             sandbox_name: "test-sandbox".to_string(),
             container_image: "openshell/sandbox:test".to_string(),

--- a/crates/openshell-supervisor-process/src/run.rs
+++ b/crates/openshell-supervisor-process/src/run.rs
@@ -51,7 +51,7 @@ pub enum SidecarExitReport {
     },
 }
 
-fn ocsf_ctx() -> &'static openshell_ocsf::SandboxContext {
+fn ocsf_ctx() -> &'static openshell_ocsf::EventContext {
     openshell_ocsf::ctx::ctx()
 }
 

--- a/crates/openshell-supervisor-process/src/supervisor_session.rs
+++ b/crates/openshell-supervisor-process/src/supervisor_session.rs
@@ -24,7 +24,7 @@ use openshell_core::proto::{
     SupervisorMessage, TcpRelayTarget, gateway_message, relay_open, supervisor_message,
 };
 use openshell_ocsf::{
-    ActivityId, ConnectionInfo, Endpoint, NetworkActivityBuilder, OcsfEvent, SandboxContext,
+    ActivityId, ConnectionInfo, Endpoint, EventContext, NetworkActivityBuilder, OcsfEvent,
     SeverityId, StatusId, ocsf_emit,
 };
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -55,7 +55,7 @@ fn ocsf_gateway_endpoint(endpoint: &str) -> Endpoint {
 }
 
 fn session_established_event(
-    ctx: &SandboxContext,
+    ctx: &EventContext,
     endpoint: &str,
     session_id: &str,
     heartbeat_secs: u32,
@@ -71,7 +71,7 @@ fn session_established_event(
         .build()
 }
 
-fn session_closed_event(ctx: &SandboxContext, endpoint: &str, sandbox_id: &str) -> OcsfEvent {
+fn session_closed_event(ctx: &EventContext, endpoint: &str, sandbox_id: &str) -> OcsfEvent {
     NetworkActivityBuilder::new(ctx)
         .activity(ActivityId::Close)
         .severity(SeverityId::Informational)
@@ -82,7 +82,7 @@ fn session_closed_event(ctx: &SandboxContext, endpoint: &str, sandbox_id: &str) 
 }
 
 fn session_failed_event(
-    ctx: &SandboxContext,
+    ctx: &EventContext,
     endpoint: &str,
     attempt: u64,
     error: &str,
@@ -139,7 +139,7 @@ fn relay_target_message(
 }
 
 fn relay_open_event(
-    ctx: &SandboxContext,
+    ctx: &EventContext,
     open: &RelayOpen,
     ssh_socket_path: &std::path::Path,
 ) -> OcsfEvent {
@@ -157,7 +157,7 @@ fn relay_open_event(
 }
 
 fn relay_closed_event(
-    ctx: &SandboxContext,
+    ctx: &EventContext,
     open: &RelayOpen,
     ssh_socket_path: &std::path::Path,
 ) -> OcsfEvent {
@@ -175,7 +175,7 @@ fn relay_closed_event(
 }
 
 fn relay_failed_event(
-    ctx: &SandboxContext,
+    ctx: &EventContext,
     open: &RelayOpen,
     ssh_socket_path: &std::path::Path,
     error: &str,
@@ -196,11 +196,7 @@ fn relay_failed_event(
     builder.build()
 }
 
-fn relay_close_from_gateway_event(
-    ctx: &SandboxContext,
-    channel_id: &str,
-    reason: &str,
-) -> OcsfEvent {
+fn relay_close_from_gateway_event(ctx: &EventContext, channel_id: &str, reason: &str) -> OcsfEvent {
     NetworkActivityBuilder::new(ctx)
         .activity(ActivityId::Close)
         .severity(SeverityId::Informational)
@@ -895,8 +891,8 @@ mod target_tests {
 mod ocsf_event_tests {
     use super::*;
 
-    fn ctx() -> SandboxContext {
-        SandboxContext {
+    fn ctx() -> EventContext {
+        EventContext {
             sandbox_id: "sbx-1".into(),
             sandbox_name: "sandbox".into(),
             container_image: "img".into(),


### PR DESCRIPTION



## Summary
<!-- 1-3 sentences: what this PR does and why -->

This is a basic, mechanical rename because not all OCSF events will originate in a sandbox; the supervisor will be extracted from the sandbox, but also the gateway will emit its own OCSF events as OCSF JSON. This rename makes room for that work to be done.

In a subsequent PR, EventContext will gain an `origin` field to distinguish where the event originated.

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

#1055

## Changes
<!-- Bullet list of key changes -->
* Rename the shared OCSF context and its callers without changing event behavior.

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
