### PR TITLE
ci(windows): make PR checks opt-in and main jobs advisory

### DIFF
--- a/.agents/skills/build-openshell-mxc-windows/SKILL.md
+++ b/.agents/skills/build-openshell-mxc-windows/SKILL.md
@@ -30,7 +30,7 @@ The Windows build lane is implemented by these tracked files:
 | `tasks/windows.toml` | Mise task entry points for `windows:*` commands. |
 | `tasks/rust.toml`, `tasks/test.toml`, and `tasks/markdown.toml` | Windows routing for compiler-bearing checks, explicit Unix-only test skips, and Markdown dependency setup. |
 | `tasks/scripts/windows-msvc.ps1` | PowerShell wrapper that enters the Visual Studio developer environment and invokes Cargo. |
-| `.github/workflows/windows-msvc.yml` | PR/merge-queue lint and test plus main/manual cache seeding and dependent binary builds on native x64 and ARM64 runners. |
+| `.github/workflows/windows-msvc.yml` | Opt-in PR lint and test plus advisory main/manual cache seeding and dependent binary builds on native x64 and ARM64 runners. |
 | `architecture/windows-msvc-build.md` | Design notes and validation contract. |
 | `.agents/skills/build-openshell-mxc-windows/` | This skill and companion reference material. |
 
@@ -193,11 +193,14 @@ order:
 The GitHub Actions jobs layer architecture-specific `Swatinem/rust-cache`
 entries for Cargo registry and dependency target artifacts with sccache's GHA
 backend for cacheable Rust compiler outputs. Failed runs also save their usable
-dependency artifacts. Pull-request mirrors and merge queues run Clippy for the
+dependency artifacts. Pull-request mirrors labeled `test:windows` run Clippy for the
 Windows-supported workspace and e2e crates plus Rust tests. Pushes to `main` and
 manual dispatches run the same lint and test commands in a cache-seed job,
 followed by a dependent release-binary build job. The seed and PR jobs use the
-same cache namespaces. The binaries are not uploaded or published.
+same cache namespaces. Merge queues do not run this workflow. Main/manual seed
+and build jobs use job-level `continue-on-error: true`; opt-in PR jobs report
+failures normally. Applying the label alone does not start a run: re-run all
+jobs in the current mirror push run, or push a new mirrored commit. The binaries are not uploaded or published.
 
 The ARM64 check/build steps in this x64-host contract are cross-builds. The
 wrapper discovers and adds host-native LLVM and Ninja to `PATH`, requires the

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,8 +1,6 @@
 name: Windows MSVC
 
 on:
-  merge_group:
-    types: [checks_requested]
   push:
     branches:
       - main
@@ -36,6 +34,8 @@ jobs:
       - id: gate
         if: github.ref != 'refs/heads/main'
         uses: ./.github/actions/pr-gate
+        with:
+          required_label: test:windows
 
   pr-check:
     name: PR lint and test (${{ matrix.arch }})
@@ -104,6 +104,8 @@ jobs:
 
   cache-seed:
     name: Seed cache (${{ matrix.arch }})
+    # Keep main/manual Windows validation advisory while the lane matures.
+    continue-on-error: true
     needs: pr_metadata
     if: >-
       needs.pr_metadata.outputs.should_run == 'true' &&
@@ -164,6 +166,7 @@ jobs:
 
   build:
     name: Build binaries (${{ matrix.arch }})
+    continue-on-error: true
     needs: cache-seed
     strategy:
       fail-fast: false

--- a/CI.md
+++ b/CI.md
@@ -12,6 +12,12 @@ PR CI that runs on NVIDIA self-hosted runners uses NVIDIA's copy-pr-bot. The bot
 
 Merge queue validation is a second integration gate for `main`. After a PR has passed the required PR-head statuses, a maintainer adds it to the merge queue. GitHub creates a temporary merge-group branch that combines the latest `main`, the queued PR, and any earlier queued PRs. The same required `OpenShell / ...` status contexts are then published against the merge-group SHA before GitHub merges it.
 
+Windows PR checks are opt-in: add `test:windows`, then select **Re-run all jobs**
+on the current Windows MSVC run. Subsequent mirrored commits run them automatically.
+Windows checks are not required for merging and do not run in merge queues.
+Main and manual runs also build release binaries, with `continue-on-error: true`
+so Windows failures do not fail the workflow.
+
 Three opt-in labels enable the long-running E2E suites:
 
 - `test:e2e` runs the Docker, rootless Podman, Kubernetes, and VM E2E suites

--- a/architecture/windows-msvc-build.md
+++ b/architecture/windows-msvc-build.md
@@ -55,7 +55,8 @@ creating misleading Windows driver artifacts.
 ## Mise Lane
 
 The GitHub Actions workflow runs Clippy for the Windows-supported workspace and
-e2e crates plus Rust tests for pull-request mirror branches and merge queues. On
+e2e crates plus Rust tests for pull-request mirror branches labeled `test:windows`.
+Merge queues do not run this workflow. On
 pushes to `main`, a cache-seed job runs the same lint and test commands before a
 dependent job builds the release binaries. Manual dispatches exercise the same
 seed-then-build path. The binaries remain CI validation artifacts and are not
@@ -146,7 +147,7 @@ break ARM64 crypto dependency builds.
 ## CI Shape
 
 The x64 GitHub Actions jobs run on `windows-2025`; native ARM64 jobs run on
-`windows-11-arm`. Pull-request mirrors and merge queues execute the matching
+`windows-11-arm`. Pull-request mirrors labeled `test:windows` execute the matching
 architecture-specific tasks:
 
 ```powershell
@@ -155,7 +156,10 @@ mise run --skip-tools windows:test:<x64|arm64>
 ```
 
 Pushes to `main` and manual dispatches first seed the shared caches with those
-same lint and test commands. After the seed succeeds, a separate job executes:
+same lint and test commands. Both seed and build jobs use job-level
+`continue-on-error: true`, so Windows job failures do not fail the main/manual
+workflow. Opt-in PR jobs still report failures normally. After the seed job
+finishes, a separate job executes:
 
 ```powershell
 mise run --skip-tools windows:build:<x64|arm64>


### PR DESCRIPTION
## Summary

Windows CI currently runs expensive lint/tests on every PR mirror and merge group. Make PR validation opt-in with `test:windows`, remove merge-group runs, and keep main/manual validation advisory so Windows failures do not fail those workflows.

The [sample x64 PR job](https://github.com/NVIDIA/OpenShell/actions/runs/34546570042/job/103100419353?pr=3267) took 24m 53s: 9m 49s linting, 9m 14s compiling/running tests, and 4m 52s cleaning/saving the cache. Test execution itself took only 70 seconds. The target-cache save failed with an explicit GitHub rate-limit warning after cleanup and compression. sccache recorded 213 hits, 792 misses, and 792 write errors, so caching is only partly effective. Rate limiting may also explain the sccache write failures, but the statistics alone do not establish that cause.

These timings and cache failures motivate reducing automatic Windows runs while cache reliability and warm-run performance are investigated. This PR changes when validation runs and how failures affect workflow status; it does not fix the cache failures.

## Related Issue

No issue required: localized CI configuration maintenance requested by a maintainer; no product or runtime behavior changes.

## Changes

- Require `test:windows` through the existing PR gate for PR lint/tests. Created the repository label; applying it requires re-running the current mirror workflow or pushing another mirrored commit.
- Remove the merge-group trigger.
- Set job-level `continue-on-error: true` on main/manual cache-seed and binary-build jobs. Opt-in PR failures remain visible normally.
- Update CI documentation, architecture guidance, and the Windows contributor skill.

## Testing

- [x] `mise run pre-commit` passes
- [x] `actionlint` passes for `.github/workflows/windows-msvc.yml`
- [x] `git diff --check` passes
- Unit/E2E additions are not applicable to this workflow-only change.

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated

