### PR TITLE
fix(deps): update DOMPurify and runtime image packages

### DIFF
--- a/architecture/build.md
+++ b/architecture/build.md
@@ -219,6 +219,8 @@ Runtime layout:
   gateway binaries must not reference `GLIBC_*` symbols newer than
   `GLIBC_2.28`; release workflows verify this before publishing artifacts. The
   gateway bundles z3, so the image does not need a distro-provided z3 runtime.
+  The base is pinned to a multi-architecture digest; distro security updates
+  require refreshing that digest and rebuilding the gateway image.
 - **VM driver**: host GNU-linked binary installed at
   `/usr/libexec/openshell/openshell-driver-vm` in Linux packages and published
   as a release artifact. Linux GNU VM driver binaries must not reference
@@ -229,7 +231,8 @@ Runtime layout:
   cache action runs. An explicitly configured VM runtime bundle is required to
   contain every non-empty embedding input; the driver build fails before
   packaging when an input is absent or empty.
-- **Supervisor**: Alpine base with `nftables`, static binary at
+- **Supervisor**: Alpine base with `nftables`; base packages are upgraded before
+  installing firewall tools to pick up distro security fixes. Static binary at
   `/openshell-sandbox` (musl by default; see `SUPERVISOR_LIBC` above). Static
   linkage keeps the binary usable when the image is mounted/extracted into
   sandbox environments (Docker extraction, Podman image volumes, Kubernetes

--- a/deploy/docker/Dockerfile.gateway
+++ b/deploy/docker/Dockerfile.gateway
@@ -8,7 +8,7 @@
 #
 # Distroless Debian provides the glibc runtime required by the binary.
 
-ARG GATEWAY_BASE_IMAGE=gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
+ARG GATEWAY_BASE_IMAGE=gcr.io/distroless/cc-debian13:nonroot@sha256:c31ff9abcb1910f3ab25c7957bdaf0bfe12a01eb546e8df2282f1c8f682b606c
 FROM ${GATEWAY_BASE_IMAGE} AS gateway
 
 ARG TARGETARCH

--- a/deploy/docker/Dockerfile.supervisor
+++ b/deploy/docker/Dockerfile.supervisor
@@ -12,7 +12,9 @@ FROM alpine:3.22 AS supervisor
 
 ARG TARGETARCH
 
-RUN apk add --no-cache nftables iptables iptables-legacy
+# Refresh base packages too: adding firewall tools does not upgrade OpenSSL.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache nftables iptables iptables-legacy
 
 # Keep the binary root-owned for Podman image-volume mounts and executable by
 # the Kubernetes network sidecar's non-root proxy UID.

--- a/scripts/lint-mermaid/package-lock.json
+++ b/scripts/lint-mermaid/package-lock.json
@@ -1114,10 +1114,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/scripts/lint-mermaid/package.json
+++ b/scripts/lint-mermaid/package.json
@@ -9,6 +9,6 @@
     "mermaid": "^11.4.0"
   },
   "overrides": {
-    "dompurify": "3.4.12"
+    "dompurify": "3.4.15"
   }
 }

--- a/skills/debug-openshell-cluster/SKILL.md
+++ b/skills/debug-openshell-cluster/SKILL.md
@@ -456,6 +456,13 @@ helm -n openshell get values openshell | grep -E 'repository|tag|supervisorImage
 
 The gateway and supervisor images should use the same release tag. A stale supervisor image can make sandbox behavior lag behind gateway policy or protocol changes.
 
+For vulnerability reports, record the running image digest and scan that exact
+artifact. The gateway includes a pinned Distroless base; the supervisor includes
+Alpine packages updated at image build time. A dependency or base-image fix only
+reaches deployed containers after rebuilding, publishing, and redeploying the
+images. Compare findings against the SBOM for that digest, not just its mutable
+`latest` or `dev` tag.
+
 For plaintext local evaluation, confirm the chart has:
 
 ```bash


### PR DESCRIPTION
## Summary

Refresh runtime image packages and the Mermaid linter's DOMPurify dependency. The supervisor previously installed firewall tools without upgrading OpenSSL already present in Alpine; rebuilt images now pick up distro package updates. No application code changes.

## Related Issue

Maintenance of upstream dependencies using published fixes. No new vulnerability is disclosed and no public security issue was filed, following `SECURITY.md`.

## Changes

- Refresh the multi-architecture `distroless/cc-debian13:nonroot` digest. Both amd64 and arm64 include `libssl3t64 3.5.7-1~deb13u2`.
- Run `apk upgrade --no-cache` before installing supervisor firewall tools, retaining Alpine 3.22. The rebuilt amd64 image includes `libssl3` and `libcrypto3` at `3.5.8-r0`.
- Pin DOMPurify to 3.4.15 and update only its npm lockfile entry.
- Document the image rebuild boundary in the architecture overview and image diagnostics skill.

## Testing

- [x] `mise run pre-commit` passed on a clean checkout of the pushed commit.
- [x] `mise run ci` passed on the same commit, including Go SDK CI, Rust dependency policy checks, lint/type checks, and unit/integration tests.
- Existing Rust unit/integration tests, 238 Python tests, 105 TypeScript tests, and auxiliary test tasks passed. Local Rust tests required `/usr/sbin` on `PATH` and a short tmpfs temporary path for filesystem/socket tests.
- `mise run e2e:docker`: passed CLI conformance and 120 Rust E2E tests with the rebuilt supervisor.
- Mermaid validation: 183 files passed; both hook-removal regression variants passed against DOMPurify 3.4.15. Markdown and SPDX checks passed.
- Built both amd64 images with `OPENSHELL_AUDITABLE=1`; verified startup and embedded `.dep-v0` metadata. Trivy 0.74.0 detected 503 Rust packages in the gateway and 386 in the supervisor, with no Rust findings and no High/Critical findings in either image.
- Trivy found no supervisor vulnerabilities. Gateway OS findings remain: 13 Medium, seven Low, and one Unknown, including zlib `CVE-2026-85091` at Medium with no fixed version reported. This PR does not claim to resolve every scanner finding.
- ARM64 base/package versions were inspected; ARM64 runtime execution was not tested.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)
- [x] Architecture documentation and related diagnostic skill updated
- [x] Existing unit and E2E coverage exercised; no application/test code changes
