### PR TITLE
fix(ci): align Trivy change detection and scan baselines

### DIFF
--- a/.agents/skills/watch-github-actions/SKILL.md
+++ b/.agents/skills/watch-github-actions/SKILL.md
@@ -125,6 +125,13 @@ gh run list --json databaseId,status,headBranch,url --jq '.[] | {id: .databaseId
 
 ## View Job Logs
 
+For `Trivy Changes`, inspect the `Resolve PR baseline` step for the base and head
+SHAs. PR runs compare the tested merge commit with its
+first parent; change detection and scans must use the same pair. On reruns, do
+not substitute the current `main` tip or the event's older PR base SHA. Merge
+groups and manual runs use their explicit baseline. Findings are reported by
+`Reject new high or critical findings`; distinguish those from scanner failures.
+
 View logs for a specific run:
 
 ```bash

--- a/.github/workflows/trivy-changes.yml
+++ b/.github/workflows/trivy-changes.yml
@@ -34,6 +34,7 @@ jobs:
       pull-requests: read
     outputs:
       should_run: ${{ steps.default.outputs.should_run || steps.changed.outputs.any_modified }}
+      base_sha: ${{ steps.comparison.outputs.base_sha }}
     steps:
       - id: default
         if: github.event_name != 'pull_request'
@@ -42,12 +43,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: github.event_name == 'pull_request'
         with:
+          ref: ${{ github.sha }}
+          # Include both parents of the exact PR merge commit, even on reruns.
+          fetch-depth: 2
           persist-credentials: false
+
+      - name: Resolve PR baseline
+        id: comparison
+        if: github.event_name == 'pull_request'
+        run: |
+          git rev-parse --verify HEAD^2 >/dev/null
+          base_sha=$(git rev-parse --verify HEAD^1)
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "Trivy comparison: $base_sha -> $(git rev-parse HEAD)"
 
       - id: changed
         if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11 # v42.1.0
         with:
+          base_sha: ${{ steps.comparison.outputs.base_sha }}
+          sha: ${{ github.sha }}
+          output_renamed_files_as_deleted_and_added: true
           # `any_modified` covers deletions, which `any_changed` omits, and a
           # failed diff has to fail the job: both otherwise report no relevant
           # change, and removing the scanner or a value fixture would skip the
@@ -73,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || inputs.base_sha }}
+      BASE_REF: ${{ needs.changes.outputs.base_sha || github.event.merge_group.base_sha || inputs.base_sha }}
       HEAD_REF: ${{ inputs.head_sha || github.sha }}
     defaults:
       run:

--- a/CI.md
+++ b/CI.md
@@ -135,9 +135,16 @@ Use a fresh `TRIVY_REPORT_DIR` for each scan session. `prepare-sarif` creates
 
 ### Pull-request change gate
 
-`Trivy Changes` scans the base and candidate when a pull request or merge group
-changes deployment configuration or scanner inputs. It fails only for new
-`HIGH` or `CRITICAL` misconfigurations and retains both report sets.
+`Trivy Changes` scans the base and candidate when a pull request changes
+deployment configuration or scanner inputs; merge groups and manual runs always
+scan. It fails only for new `HIGH` or `CRITICAL` misconfigurations and retains
+both report sets.
+
+For pull requests, change detection compares the exact tested merge commit with
+its first parent. Both detection and scanning use that same pair. This excludes
+unrelated changes on `main` even when the event carries an older base SHA or a
+job is rerun. Merge groups use the event's base SHA; manual runs use the supplied
+base and head. A missing revision or invalid PR merge checkout fails the gate.
 
 The candidate ignore file is validated, but the baseline policy applies to both
 scans so a change cannot exempt its own finding. Existing profiles are compared

--- a/architecture/build.md
+++ b/architecture/build.md
@@ -494,6 +494,10 @@ references. Publication batches respect GitHub's limit of 20 SARIF runs.
 The PR/merge-group gate scans base and candidate with the same scanner and rejects
 new `HIGH` or `CRITICAL` configuration findings. Its stable
 `OpenShell / Trivy Changes` status succeeds when nothing relevant changed.
+For PRs, the baseline is the first parent of the exact merge commit being tested,
+not the event's potentially older base SHA or the current branch tip. Change
+detection and both scans use that same immutable pair, including on reruns.
+Merge groups and manual runs retain their explicit baseline and always scan.
 Image CVEs need the standalone scan. The reporting and gate invariants are:
 
 - A structurally invalid Trivy report is an error, not an empty finding set.


### PR DESCRIPTION
## Summary

A documentation-only PR could fail Trivy because its tested merge commit was compared with an older base SHA from the event. Resolve the baseline from the tested merge commit's first parent and use that same pair for change detection and scanning, including reruns.

## Related Issue

No issue required: localized CI comparison bug. Observed on the documentation-only PR #2048 ([failed Trivy run](https://github.com/NVIDIA/OpenShell/actions/runs/34513241432)).

## Changes

- Check out the exact PR merge SHA with both parents and reject a non-merge checkout.
- Pass explicit base/head SHAs to the existing `changed-files` action and use the resolved base for Trivy. Count moved files as additions and deletions so moving a file out of a watched directory still triggers scanning.
- Keep merge-group and manual-run behavior unchanged; update CI documentation and troubleshooting guidance.

## Testing

- [x] `mise run pre-commit` passes on the pushed commit.
- [x] `mise run ci` passes on the pushed commit (lint, compile/type checks, and tests).
- Executed the pinned `changed-files` action against shallow synthetic Git histories: documentation-only changes with an older event baseline skip scanning; Helm modifications, deletions, and moves trigger scanning; invalid non-merge checkouts fail.
- Real Trivy scans of the chart: adding harmless metadata to the affected ClusterRole passes while its five existing alerts remain; adding wildcard permissions fails.
- Actionlint, ShellCheck, Zizmor, and Markdown validation pass.
- No application or sandbox runtime changes; no E2E changes required.

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)
- [x] Architecture documentation updated
