### PR TITLE
fix(gateway): disable JWT expiry for Podman dev

### DIFF
--- a/tasks/scripts/gateway-podman.sh
+++ b/tasks/scripts/gateway-podman.sh
@@ -231,7 +231,7 @@ signing_key_path = "${TLS_DIR}/jwt/signing.pem"
 public_key_path = "${TLS_DIR}/jwt/public.pem"
 kid_path = "${TLS_DIR}/jwt/kid"
 gateway_id = "${GATEWAY_NAME}"
-ttl_secs = 3600
+ttl_secs = 0
 
 [openshell.drivers.podman]
 supervisor_image = "${SUPERVISOR_IMAGE}"


### PR DESCRIPTION
## Summary

Disable JWT expiry in the local Podman gateway configuration so sandbox tokens remain valid across restarts and long-running local sessions.

## Related Issue
No issue required: localized one-line fix to the local development gateway configuration.

## Changes
- Set the Podman gateway JWT `ttl_secs` to `0`, matching the non-expiring local default.
- Preserve the one-hour expiry used by shared Kubernetes deployments.

## Testing
- `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
