### PR TITLE
feat(supervisor): set up sandbox netns via rtnetlink instead of ip/nsenter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4682,16 +4757,19 @@ dependencies = [
  "base64",
  "bytes",
  "capctl",
+ "futures-util",
  "hex",
  "ipnet",
  "landlock",
  "libc",
  "miette",
+ "netlink-packet-route",
  "nix 0.29.0",
  "openshell-core",
  "openshell-ocsf",
  "openshell-policy",
  "rand 0.10.2",
+ "rtnetlink",
  "russh",
  "rustix 1.1.4",
  "seccompiler",
@@ -5962,6 +6040,24 @@ dependencies = [
  "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.27.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/openshell-supervisor-process/Cargo.toml
+++ b/crates/openshell-supervisor-process/Cargo.toml
@@ -39,7 +39,10 @@ rustix = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 capctl = "0.2.4"
+futures-util = { version = "0.3", default-features = false }
 landlock = "0.4"
+netlink-packet-route = "0.19"
+rtnetlink = "0.14"
 seccompiler = "0.5"
 socket2 = { workspace = true }
 tempfile = "3"

--- a/crates/openshell-supervisor-process/src/netns/mod.rs
+++ b/crates/openshell-supervisor-process/src/netns/mod.rs
@@ -7,6 +7,7 @@
 //! the sandbox to the host. This ensures the sandboxed process can only
 //! communicate through the proxy running on the host side of the veth.
 
+mod netlink;
 mod nft_ruleset;
 
 use miette::{IntoDiagnostic, Result};
@@ -26,7 +27,6 @@ const SANDBOX_IP_SUFFIX: u8 = 2;
 /// this listener before the bypass fence runs.
 pub const POLICY_DNS_PORT: u16 = 15_053;
 pub const TRANSPARENT_TCP_PORT: u16 = 15_001;
-const IP_SEARCH_PATHS: &[&str] = &["/usr/sbin/ip", "/sbin/ip", "/usr/bin/ip", "/bin/ip"];
 const NSENTER_SEARCH_PATHS: &[&str] = &[
     "/usr/bin/nsenter",
     "/bin/nsenter",
@@ -88,88 +88,25 @@ impl NetworkNamespace {
                 .build()
         );
 
-        // Create the namespace
-        run_ip(&["netns", "add", &name])?;
+        // Create the FD-owned namespace, bind-mounted at netns_path via
+        // `mount(2)` (not `ip netns add`) so the nsenter-based nft path still
+        // reaches it. Returns a persistent fd for the setns paths.
+        let ns_fd = netlink::create_netns_fd(&name)?;
 
-        // Create veth pair
-        if let Err(e) = run_ip(&[
-            "link",
-            "add",
-            &veth_host,
-            "type",
-            "veth",
-            "peer",
-            "name",
-            &veth_sandbox,
-        ]) {
-            // Cleanup namespace on failure
-            let _ = run_ip(&["netns", "delete", &name]);
+        // Host side: veth pair, move peer into the namespace, host addr + up.
+        if let Err(e) = netlink::setup_host_side(&veth_host, &veth_sandbox, host_ip, 24, ns_fd) {
+            let _ = netlink::destroy_netns(&name, ns_fd);
             return Err(e);
         }
 
-        // Move sandbox veth into namespace
-        if let Err(e) = run_ip(&["link", "set", &veth_sandbox, "netns", &name]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
+        // Sandbox side: addr on veth-s, veth-s up, lo up, default route.
+        if let Err(e) = netlink::setup_sandbox_side(ns_fd, &veth_sandbox, sandbox_ip, 24, host_ip) {
+            let _ = netlink::delete_link(&veth_host);
+            let _ = netlink::destroy_netns(&name, ns_fd);
             return Err(e);
         }
 
-        // Configure host side
-        let host_cidr = format!("{host_ip}/24");
-        if let Err(e) = run_ip(&["addr", "add", &host_cidr, "dev", &veth_host]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        if let Err(e) = run_ip(&["link", "set", &veth_host, "up"]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        // Configure sandbox side (inside namespace)
-        let sandbox_cidr = format!("{sandbox_ip}/24");
-        if let Err(e) = run_ip_netns(&name, &["addr", "add", &sandbox_cidr, "dev", &veth_sandbox]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        if let Err(e) = run_ip_netns(&name, &["link", "set", &veth_sandbox, "up"]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        // Bring up loopback in namespace
-        if let Err(e) = run_ip_netns(&name, &["link", "set", "lo", "up"]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        // Add default route via host
-        let host_ip_str = host_ip.to_string();
-        if let Err(e) = run_ip_netns(&name, &["route", "add", "default", "via", &host_ip_str]) {
-            let _ = run_ip(&["link", "delete", &veth_host]);
-            let _ = run_ip(&["netns", "delete", &name]);
-            return Err(e);
-        }
-
-        // Open the namespace file descriptor for later use with setns
-        let ns_path = openshell_core::container_paths::netns_path(&name);
-        let ns_fd = match nix::fcntl::open(
-            ns_path.as_path(),
-            nix::fcntl::OFlag::O_RDONLY,
-            nix::sys::stat::Mode::empty(),
-        ) {
-            Ok(fd) => Some(fd),
-            Err(e) => {
-                warn!(error = %e, "Failed to open namespace fd, will use nsenter fallback");
-                None
-            }
-        };
+        let ns_fd = Some(ns_fd);
 
         openshell_ocsf::ocsf_emit!(
             openshell_ocsf::ConfigStateChangeBuilder::new(openshell_ocsf::ctx::ctx())
@@ -337,10 +274,11 @@ impl NetworkNamespace {
         // default route. Install only the active synthetic IPv6 epoch so the
         // kernel reaches the nft OUTPUT hook; REDIRECT then reroutes it to
         // the local transparent listener.
-        run_ip_netns(
-            &self.name,
-            &["-6", "route", "replace", synthetic_ipv6_cidr, "dev", "lo"],
-        )?;
+        let ns_fd = self
+            .ns_fd
+            .ok_or_else(|| miette::miette!("no namespace fd available for route setup"))?;
+        let v6_cidr: ipnet::IpNet = synthetic_ipv6_cidr.parse().into_diagnostic()?;
+        netlink::replace_route_dev_lo_in_netns(ns_fd, v6_cidr)?;
         let nft_path = find_nft().ok_or_else(|| {
             miette::miette!(
                 "trusted nft helper not found; policy DNS and transparent TCP require nftables"
@@ -385,9 +323,11 @@ impl NetworkNamespace {
                 .parse::<ipnet::IpNet>()
                 .into_diagnostic()?,
         ];
-        for family in ["-4", "-6"] {
-            let routes =
-                run_ip_netns_output(&self.name, &[family, "route", "show", "table", "all"])?;
+        let ns_fd = self
+            .ns_fd
+            .ok_or_else(|| miette::miette!("no namespace fd available for route validation"))?;
+        for v6 in [false, true] {
+            let routes = netlink::dump_route_prefixes_in_netns(ns_fd, v6)?;
             if let Some((route, pool)) = first_route_overlap(&routes, &reserved) {
                 return Err(miette::miette!(
                     "synthetic address pool {pool} overlaps workload route {route}; refusing to enable policy DNS"
@@ -552,13 +492,9 @@ impl Drop for NetworkNamespace {
     fn drop(&mut self) {
         debug!(namespace = %self.name, "Cleaning up network namespace");
 
-        // Close the fd if we have one
-        if let Some(fd) = self.ns_fd.take() {
-            let _ = nix::unistd::close(fd);
-        }
-
-        // Delete the host-side veth (this also removes the peer)
-        if let Err(e) = run_ip(&["link", "delete", &self.veth_host]) {
+        // Delete the host-side veth (this also removes the sandbox peer).
+        // Do this before freeing the namespace so ordering stays explicit.
+        if let Err(e) = netlink::delete_link(&self.veth_host) {
             warn!(
                 error = %e,
                 veth = %self.veth_host,
@@ -566,13 +502,16 @@ impl Drop for NetworkNamespace {
             );
         }
 
-        // Delete the namespace
-        if let Err(e) = run_ip(&["netns", "delete", &self.name]) {
-            warn!(
-                error = %e,
-                namespace = %self.name,
-                "Failed to delete network namespace"
-            );
+        // Free the namespace: close the fd, unmount the bind mount, remove the
+        // target file (no `ip netns delete`).
+        if let Some(fd) = self.ns_fd.take() {
+            if let Err(e) = netlink::destroy_netns(&self.name, fd) {
+                warn!(
+                    error = %e,
+                    namespace = %self.name,
+                    "Failed to remove network namespace mount"
+                );
+            }
         }
 
         openshell_ocsf::ocsf_emit!(
@@ -596,9 +535,9 @@ impl Drop for NetworkNamespace {
 /// # Errors
 ///
 /// Returns an error if proxy mode is requested but the namespace cannot be
-/// created (e.g., missing `CAP_NET_ADMIN` / `CAP_SYS_ADMIN` or `iproute2`).
-/// Failure to install nftables bypass-detection rules is non-fatal and is
-/// reported via OCSF instead.
+/// created (e.g., missing `CAP_NET_ADMIN` / `CAP_SYS_ADMIN`). Failure to
+/// install nftables bypass-detection rules is non-fatal and is reported via
+/// OCSF instead.
 pub fn create_netns_for_proxy(
     policy: &openshell_core::policy::SandboxPolicy,
 ) -> Result<Option<NetworkNamespace>> {
@@ -632,7 +571,7 @@ pub fn create_netns_for_proxy(
         }
         Err(e) => Err(miette::miette!(
             "Network namespace creation failed and proxy mode requires isolation. \
-             Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available and iproute2 is installed. \
+             Ensure CAP_NET_ADMIN and CAP_SYS_ADMIN are available. \
              Error: {e}"
         )),
     }
@@ -825,29 +764,6 @@ fn cleanup_sidecar_iptables_legacy_rule_families(ipv4_cmd: &str, ipv6_cmd: Optio
     }
 }
 
-/// Run an `ip` command on the host.
-fn run_ip(args: &[&str]) -> Result<()> {
-    let ip_path = find_trusted_binary("ip", IP_SEARCH_PATHS)?;
-
-    debug!(command = %format!("{ip_path} {}", args.join(" ")), "Running ip command");
-
-    let output = Command::new(ip_path)
-        .args(args)
-        .output()
-        .into_diagnostic()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(miette::miette!(
-            "{ip_path} {} failed: {}",
-            args.join(" "),
-            stderr.trim()
-        ));
-    }
-
-    Ok(())
-}
-
 fn run_iptables_legacy_current_namespace(iptables_cmd: &str, args: &[&str]) -> Result<()> {
     debug!(
         command = %format!("{iptables_cmd} {}", args.join(" ")),
@@ -910,73 +826,25 @@ fn run_nft_commands_current_namespace(
     Ok(())
 }
 
-/// Run an `ip` command inside a network namespace via `nsenter --net=`.
-///
-/// We use `nsenter` instead of `ip netns exec` because `ip netns exec`
-/// remounts `/sys` to reflect the target namespace's sysfs entries. That
-/// sysfs remount requires real `CAP_SYS_ADMIN` in the host user namespace,
-/// which is unavailable in rootless container runtimes (e.g. rootless
-/// Podman). `nsenter --net=` enters only the network namespace without
-/// changing the mount namespace, avoiding the sysfs remount entirely.
-/// The supervisor's operations (addr add, link set, route add) are all
-/// netlink-based and do not need sysfs access.
-fn run_ip_netns(netns: &str, args: &[&str]) -> Result<()> {
-    run_ip_netns_output(netns, args).map(|_| ())
-}
-
-fn run_ip_netns_output(netns: &str, args: &[&str]) -> Result<String> {
-    let ip_path = find_trusted_binary("ip", IP_SEARCH_PATHS)?;
-    let nsenter_path = find_trusted_binary("nsenter", NSENTER_SEARCH_PATHS)?;
-    let ns_path = openshell_core::container_paths::netns_path(netns);
-    let net_flag = format!("--net={}", ns_path.display());
-
-    let mut full_args = vec![net_flag.as_str(), "--", ip_path];
-    full_args.extend(args);
-
-    debug!(
-        command = %format!("{nsenter_path} {}", full_args.join(" ")),
-        "Running ip in namespace via nsenter"
-    );
-
-    let output = Command::new(nsenter_path)
-        .args(&full_args)
-        .output()
-        .into_diagnostic()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(miette::miette!(
-            "{nsenter_path} --net={} {ip_path} {} failed: {}",
-            ns_path.display(),
-            args.join(" "),
-            stderr.trim()
-        ));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
 fn first_route_overlap(
-    routes: &str,
+    routes: &[ipnet::IpNet],
     reserved: &[ipnet::IpNet],
 ) -> Option<(ipnet::IpNet, ipnet::IpNet)> {
-    routes.lines().find_map(|line| {
-        line.split_whitespace().find_map(|token| {
-            let route = token
-                .parse::<ipnet::IpNet>()
-                .ok()
-                .or_else(|| token.parse::<IpAddr>().ok().map(ipnet::IpNet::from))?;
-            reserved
-                .iter()
-                .copied()
-                .find(|pool| {
-                    let same_family = route.addr().is_ipv4() == pool.addr().is_ipv4();
-                    let overlaps =
-                        route.contains(&pool.network()) || pool.contains(&route.network());
-                    same_family && overlaps
-                })
-                .map(|pool| (route, pool))
-        })
+    routes.iter().find_map(|route| {
+        // A default route (0.0.0.0/0 or ::/0) covers everything but never
+        // shadows a specific synthetic pool, so it is not a real overlap.
+        if route.prefix_len() == 0 {
+            return None;
+        }
+        reserved
+            .iter()
+            .copied()
+            .find(|pool| {
+                let same_family = route.addr().is_ipv4() == pool.addr().is_ipv4();
+                let overlaps = route.contains(&pool.network()) || pool.contains(&route.network());
+                same_family && overlaps
+            })
+            .map(|pool| (*route, pool))
     })
 }
 
@@ -1111,6 +979,19 @@ mod tests {
     // These tests require root and network namespace support
     // Run with: sudo cargo test -- --ignored
 
+    /// Root-only: create() builds a working namespace with host veth, sandbox
+    /// address, and default route — with no external `ip`/`nsenter` process.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn create_builds_namespace_via_netlink() {
+        let ns = NetworkNamespace::create().expect("create netns");
+        assert_eq!(ns.host_ip().to_string(), "10.200.0.1");
+        assert_eq!(ns.sandbox_ip().to_string(), "10.200.0.2");
+        assert!(ns.name().starts_with("sandbox-"));
+        assert!(ns.ns_fd().is_some(), "namespace must be FD-owned");
+        // Dropping ns tears everything down via netlink + fd close.
+    }
+
     #[test]
     fn find_trusted_binary_uses_absolute_existing_file() {
         let tempdir = tempfile::tempdir().unwrap();
@@ -1191,8 +1072,11 @@ fe800000000000000000000000000001 02 40 20 80 eth0
             "198.18.1.0/25".parse().unwrap(),
             "fd23:6f70:656e:1::/120".parse().unwrap(),
         ];
-        let routes = "default via 10.200.0.1 dev veth\n198.18.0.0/15 dev eth1\n";
-        let (route, pool) = first_route_overlap(routes, &reserved).expect("collision");
+        let routes: Vec<ipnet::IpNet> = ["0.0.0.0/0", "198.18.0.0/15"]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        let (route, pool) = first_route_overlap(&routes, &reserved).expect("collision");
         assert_eq!(route.to_string(), "198.18.0.0/15");
         assert_eq!(pool.to_string(), "198.18.1.0/25");
     }
@@ -1203,8 +1087,11 @@ fe800000000000000000000000000001 02 40 20 80 eth0
             "198.18.1.0/25".parse().unwrap(),
             "fd23:6f70:656e:1::/120".parse().unwrap(),
         ];
-        let routes = "default via 10.200.0.1 dev veth\n10.200.0.0/24 dev veth\n";
-        assert_eq!(first_route_overlap(routes, &reserved), None);
+        let routes: Vec<ipnet::IpNet> = ["0.0.0.0/0", "10.200.0.0/24"]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        assert_eq!(first_route_overlap(&routes, &reserved), None);
     }
 
     #[test]

--- a/crates/openshell-supervisor-process/src/netns/netlink.rs
+++ b/crates/openshell-supervisor-process/src/netns/netlink.rs
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process network-namespace programming over route netlink.
+//!
+//! Replaces shelling out to `ip`/`nsenter` for sandbox netns setup. All
+//! `rtnetlink` (async) work is confined here, driven from synchronous callers
+//! via a local `current_thread` runtime. Host-side operations run on the
+//! calling thread; namespace-scoped operations run on a dedicated OS thread
+//! that `setns()` into the target namespace first.
+
+use std::ffi::CString;
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::RawFd;
+use std::path::Path;
+
+use futures_util::stream::TryStreamExt;
+use miette::{IntoDiagnostic, Result, miette};
+use netlink_packet_route::route::{RouteAddress, RouteAttribute};
+
+/// Bind-mount the calling thread's network namespace onto `target`.
+///
+/// Equivalent to what `ip netns add` does internally, but via `mount(2)` so no
+/// external binary is required. Must run on the thread that just `unshare`d.
+fn bind_mount_current_netns(target: &Path) -> Result<()> {
+    let src = CString::new("/proc/thread-self/ns/net").expect("static path has no NUL");
+    let tgt = CString::new(target.as_os_str().as_bytes()).into_diagnostic()?;
+    let fstype = CString::new("none").expect("static string has no NUL");
+    // SAFETY: libc FFI; bind-mounts the netns inode onto the target file.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::mount(
+            src.as_ptr(),
+            tgt.as_ptr(),
+            fstype.as_ptr(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if rc != 0 {
+        return Err(miette!(
+            "bind-mount netns onto {} failed: {}",
+            target.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
+/// Unmount and remove the netns bind-mount file at `ns_path` (best-effort
+/// unmount; propagates only the file-removal error).
+fn unmount_and_remove(ns_path: &Path) -> Result<()> {
+    if let Ok(tgt) = CString::new(ns_path.as_os_str().as_bytes()) {
+        // SAFETY: libc FFI; lazy detach so a busy mount still unwinds.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::umount2(tgt.as_ptr(), libc::MNT_DETACH);
+        }
+    }
+    std::fs::remove_file(ns_path).into_diagnostic()
+}
+
+/// Create a fresh, FD-owned network namespace named `name`.
+///
+/// Runs `unshare(CLONE_NEWNET)` on a short-lived thread and bind-mounts the new
+/// namespace onto `netns_path(name)` (via `mount(2)`, not `ip netns add`) so it
+/// persists and stays reachable for the `nsenter`-based nft path. Returns a raw
+/// fd opened on that path for the `setns` paths. The caller owns both and frees
+/// them with [`destroy_netns`].
+pub fn create_netns_fd(name: &str) -> Result<RawFd> {
+    let ns_path = openshell_core::container_paths::netns_path(name);
+    if let Some(dir) = ns_path.parent() {
+        std::fs::create_dir_all(dir).into_diagnostic()?;
+    }
+    // Create the mount-target file (as `ip netns add` does).
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&ns_path)
+        .into_diagnostic()?;
+
+    // Unshare a new netns on a dedicated thread and bind-mount it onto the
+    // target path. `/proc/thread-self` reflects THIS thread's namespaces,
+    // unlike `/proc/self` which follows the thread-group leader.
+    let target = ns_path.clone();
+    let (tx, rx) = std::sync::mpsc::channel::<Result<()>>();
+    std::thread::spawn(move || {
+        let result = (|| -> Result<()> {
+            // SAFETY: unshare affects only this dedicated, short-lived thread.
+            #[allow(unsafe_code)]
+            if unsafe { libc::unshare(libc::CLONE_NEWNET) } != 0 {
+                return Err(miette!(
+                    "unshare(CLONE_NEWNET) failed: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            bind_mount_current_netns(&target)
+        })();
+        let _ = tx.send(result);
+    });
+    if let Err(e) = rx
+        .recv()
+        .map_err(|_| miette!("netns creation thread panicked"))?
+    {
+        let _ = std::fs::remove_file(&ns_path);
+        return Err(e);
+    }
+
+    // Open a persistent fd on the bind-mounted netns for the `setns` paths.
+    match nix::fcntl::open(
+        ns_path.as_path(),
+        nix::fcntl::OFlag::O_RDONLY,
+        nix::sys::stat::Mode::empty(),
+    ) {
+        Ok(fd) => Ok(fd),
+        Err(e) => {
+            let _ = unmount_and_remove(&ns_path);
+            Err(e).into_diagnostic()
+        }
+    }
+}
+
+/// Tear down a namespace created by [`create_netns_fd`]: close the fd, unmount
+/// the bind mount, and remove the target file.
+pub fn destroy_netns(name: &str, fd: RawFd) -> Result<()> {
+    // SAFETY: fd is owned by the caller and dropped here.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::close(fd);
+    }
+    let ns_path = openshell_core::container_paths::netns_path(name);
+    unmount_and_remove(&ns_path)
+}
+
+/// Run `work` on a fresh, short-lived OS thread and wait for its result.
+///
+/// `create()` is invoked from within a tokio runtime on some drivers, so the
+/// local `current_thread` runtime in [`block_on_netlink`] must never be built
+/// on the caller's thread (that panics with "Cannot start a runtime from
+/// within a runtime"). Running on a dedicated thread also gives the setns path
+/// a thread whose namespace state is discarded on exit.
+fn on_thread<T, W>(work: W) -> Result<T>
+where
+    T: Send + 'static,
+    W: FnOnce() -> Result<T> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel::<Result<T>>();
+    std::thread::spawn(move || {
+        let _ = tx.send(work());
+    });
+    rx.recv()
+        .map_err(|_| miette!("netlink worker thread panicked"))?
+}
+
+/// Build a local current-thread runtime, open a route-netlink connection
+/// scoped to the current thread's network namespace, run `f`, then tear the
+/// connection task down.
+///
+/// Must be called on a dedicated thread (see [`on_thread`]) — never directly
+/// on a thread already driving a tokio runtime.
+fn block_on_netlink<T, F>(f: impl FnOnce(rtnetlink::Handle) -> F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .into_diagnostic()?;
+    rt.block_on(async move {
+        let (connection, handle, _) = rtnetlink::new_connection().into_diagnostic()?;
+        let conn_task = tokio::spawn(connection);
+        let result = f(handle).await;
+        conn_task.abort();
+        result
+    })
+}
+
+/// Resolve a link index by interface name in the current netns.
+async fn link_index_by_name(handle: &rtnetlink::Handle, name: &str) -> Result<u32> {
+    let mut links = handle.link().get().match_name(name.to_string()).execute();
+    let msg = links
+        .try_next()
+        .await
+        .into_diagnostic()?
+        .ok_or_else(|| miette!("link {name} not found"))?;
+    Ok(msg.header.index)
+}
+
+/// Create the veth pair, move the sandbox peer into `ns_fd`, and configure the
+/// host end (address + up). Runs in the caller's (host) network namespace.
+pub fn setup_host_side(
+    veth_host: &str,
+    veth_sandbox: &str,
+    host_ip: IpAddr,
+    prefix: u8,
+    ns_fd: RawFd,
+) -> Result<()> {
+    let veth_host = veth_host.to_string();
+    let veth_sandbox = veth_sandbox.to_string();
+    on_thread(move || {
+        block_on_netlink(move |handle| async move {
+            // Create veth pair.
+            handle
+                .link()
+                .add()
+                .veth(veth_host.clone(), veth_sandbox.clone())
+                .execute()
+                .await
+                .into_diagnostic()?;
+
+            // Move the sandbox peer into the target namespace by fd.
+            let sandbox_idx = link_index_by_name(&handle, &veth_sandbox).await?;
+            handle
+                .link()
+                .set(sandbox_idx)
+                .setns_by_fd(ns_fd)
+                .execute()
+                .await
+                .into_diagnostic()?;
+
+            // Configure the host end: address + up.
+            let host_idx = link_index_by_name(&handle, &veth_host).await?;
+            handle
+                .address()
+                .add(host_idx, host_ip, prefix)
+                .execute()
+                .await
+                .into_diagnostic()?;
+            handle
+                .link()
+                .set(host_idx)
+                .up()
+                .execute()
+                .await
+                .into_diagnostic()?;
+            Ok(())
+        })
+    })
+}
+
+/// Run `work` on a dedicated OS thread that has `setns()`'d into `ns_fd`.
+///
+/// Mirrors the existing `bind_tcp_in_netns` pattern: a short-lived thread
+/// enters the network namespace and exits, so no thread-pool worker is left
+/// with contaminated namespace state.
+fn in_netns_thread<T, W>(ns_fd: RawFd, work: W) -> Result<T>
+where
+    T: Send + 'static,
+    W: FnOnce() -> Result<T> + Send + 'static,
+{
+    on_thread(move || {
+        // SAFETY: setns on a dedicated, short-lived thread.
+        #[allow(unsafe_code)]
+        if unsafe { libc::setns(ns_fd, libc::CLONE_NEWNET) } != 0 {
+            return Err(miette!("setns failed: {}", std::io::Error::last_os_error()));
+        }
+        work()
+    })
+}
+
+/// Configure the sandbox end inside the namespace: address, link up, loopback
+/// up, and default route via the host gateway.
+pub fn setup_sandbox_side(
+    ns_fd: RawFd,
+    veth_sandbox: &str,
+    sandbox_ip: IpAddr,
+    prefix: u8,
+    gateway: IpAddr,
+) -> Result<()> {
+    let veth_sandbox = veth_sandbox.to_string();
+    in_netns_thread(ns_fd, move || {
+        block_on_netlink(move |handle| async move {
+            let sandbox_idx = link_index_by_name(&handle, &veth_sandbox).await?;
+            handle
+                .address()
+                .add(sandbox_idx, sandbox_ip, prefix)
+                .execute()
+                .await
+                .into_diagnostic()?;
+            handle
+                .link()
+                .set(sandbox_idx)
+                .up()
+                .execute()
+                .await
+                .into_diagnostic()?;
+
+            let lo_idx = link_index_by_name(&handle, "lo").await?;
+            handle
+                .link()
+                .set(lo_idx)
+                .up()
+                .execute()
+                .await
+                .into_diagnostic()?;
+
+            // Default route via the host gateway.
+            let route = handle.route().add();
+            match gateway {
+                IpAddr::V4(gw) => route.v4().gateway(gw).execute().await.into_diagnostic()?,
+                IpAddr::V6(gw) => route.v6().gateway(gw).execute().await.into_diagnostic()?,
+            }
+            Ok(())
+        })
+    })
+}
+
+/// Delete a link by name in the current (host) network namespace. Removing a
+/// veth end removes its peer too.
+pub fn delete_link(name: &str) -> Result<()> {
+    let name = name.to_string();
+    on_thread(move || {
+        block_on_netlink(move |handle| async move {
+            let idx = link_index_by_name(&handle, &name).await?;
+            handle.link().del(idx).execute().await.into_diagnostic()?;
+            Ok(())
+        })
+    })
+}
+
+/// Replace a route for `cidr` with output interface `lo`, inside `ns_fd`.
+/// Used to attract the synthetic IPv6 pool to the local transparent listener.
+pub fn replace_route_dev_lo_in_netns(ns_fd: RawFd, cidr: ipnet::IpNet) -> Result<()> {
+    in_netns_thread(ns_fd, move || {
+        block_on_netlink(move |handle| async move {
+            let lo = link_index_by_name(&handle, "lo").await?;
+            match cidr {
+                ipnet::IpNet::V4(n) => handle
+                    .route()
+                    .add()
+                    .v4()
+                    .destination_prefix(n.addr(), n.prefix_len())
+                    .output_interface(lo)
+                    .replace()
+                    .execute()
+                    .await
+                    .into_diagnostic()?,
+                ipnet::IpNet::V6(n) => handle
+                    .route()
+                    .add()
+                    .v6()
+                    .destination_prefix(n.addr(), n.prefix_len())
+                    .output_interface(lo)
+                    .replace()
+                    .execute()
+                    .await
+                    .into_diagnostic()?,
+            }
+            Ok(())
+        })
+    })
+}
+
+/// Dump destination prefixes of all routes for one family inside `ns_fd`. A
+/// missing destination attribute denotes the default route and is returned as
+/// `0.0.0.0/0` or `::/0`.
+pub fn dump_route_prefixes_in_netns(ns_fd: RawFd, v6: bool) -> Result<Vec<ipnet::IpNet>> {
+    in_netns_thread(ns_fd, move || {
+        block_on_netlink(move |handle| async move {
+            let ip_version = if v6 {
+                rtnetlink::IpVersion::V6
+            } else {
+                rtnetlink::IpVersion::V4
+            };
+            let mut routes = handle.route().get(ip_version).execute();
+            let mut out = Vec::new();
+            while let Some(route) = routes.try_next().await.into_diagnostic()? {
+                let prefix_len = route.header.destination_prefix_length;
+                let dst = route.attributes.iter().find_map(|attr| match attr {
+                    RouteAttribute::Destination(RouteAddress::Inet(a)) => Some(IpAddr::V4(*a)),
+                    RouteAttribute::Destination(RouteAddress::Inet6(a)) => Some(IpAddr::V6(*a)),
+                    _ => None,
+                });
+                let addr = dst.unwrap_or(if v6 {
+                    IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+                } else {
+                    IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+                });
+                if let Ok(net) = ipnet::IpNet::new(addr, prefix_len) {
+                    out.push(net);
+                }
+            }
+            Ok(out)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Root-only: creating an FD-owned netns yields an fd pointing at a
+    /// different network namespace than the caller's.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn create_netns_fd_is_isolated() {
+        let self_ns = std::fs::read_link("/proc/thread-self/ns/net").unwrap();
+        let fd = create_netns_fd("nl-test-iso").expect("create netns fd");
+        let created_ns = std::fs::read_link(format!("/proc/self/fd/{fd}")).unwrap();
+        assert_ne!(
+            self_ns, created_ns,
+            "created namespace must differ from the caller's"
+        );
+        let _ = destroy_netns("nl-test-iso", fd);
+    }
+
+    /// Root-only: host-side setup creates veth-h on the host and moves veth-s
+    /// out of the host namespace.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn setup_host_side_creates_and_moves() {
+        let ns_fd = create_netns_fd("nl-test-host").expect("netns fd");
+        let host_ip: IpAddr = "10.200.0.1".parse().unwrap();
+        let veth_h = "veth-h-test0001";
+        let veth_s = "veth-s-test0001";
+
+        setup_host_side(veth_h, veth_s, host_ip, 24, ns_fd).expect("host side");
+
+        let host_has_h = block_on_netlink(|h| async move {
+            Ok(link_index_by_name(&h, "veth-h-test0001").await.is_ok())
+        })
+        .unwrap();
+        assert!(host_has_h, "veth-h must exist on host");
+        let host_has_s = block_on_netlink(|h| async move {
+            Ok(link_index_by_name(&h, "veth-s-test0001").await.is_ok())
+        })
+        .unwrap();
+        assert!(!host_has_s, "veth-s must have moved into the netns");
+
+        let _ = delete_link(veth_h);
+        let _ = destroy_netns("nl-test-host", ns_fd);
+    }
+
+    /// Root-only: after host setup, sandbox-side setup installs the sandbox
+    /// address and a default route inside the namespace.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn setup_sandbox_side_installs_addr_and_route() {
+        let ns_fd = create_netns_fd("nl-test-sbx").expect("netns fd");
+        let host_ip: IpAddr = "10.200.0.1".parse().unwrap();
+        let sandbox_ip: IpAddr = "10.200.0.2".parse().unwrap();
+        let veth_h = "veth-h-test0002";
+        let veth_s = "veth-s-test0002";
+
+        setup_host_side(veth_h, veth_s, host_ip, 24, ns_fd).expect("host side");
+        setup_sandbox_side(ns_fd, veth_s, sandbox_ip, 24, host_ip).expect("sandbox side");
+
+        let routes = dump_route_prefixes_in_netns(ns_fd, false).expect("dump v4 routes");
+        assert!(
+            routes.iter().any(|p| p.prefix_len() == 0),
+            "default route must be present in the namespace"
+        );
+
+        let _ = delete_link(veth_h);
+        let _ = destroy_netns("nl-test-sbx", ns_fd);
+    }
+
+    /// Root-only: delete_link removes a host veth end.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn delete_link_removes_interface() {
+        let ns_fd = create_netns_fd("nl-test-del").expect("netns fd");
+        let host_ip: IpAddr = "10.200.0.1".parse().unwrap();
+        setup_host_side("veth-h-test0003", "veth-s-test0003", host_ip, 24, ns_fd)
+            .expect("host side");
+
+        delete_link("veth-h-test0003").expect("delete");
+
+        let still_there = block_on_netlink(|h| async move {
+            Ok(link_index_by_name(&h, "veth-h-test0003").await.is_ok())
+        })
+        .unwrap();
+        assert!(!still_there, "veth-h must be gone after delete_link");
+        let _ = destroy_netns("nl-test-del", ns_fd);
+    }
+
+    /// Root-only: dump_route_prefixes_in_netns sees a route added on lo.
+    #[test]
+    #[ignore = "requires root / CAP_NET_ADMIN"]
+    fn replace_and_dump_lo_route() {
+        let ns_fd = create_netns_fd("nl-test-route").expect("netns fd");
+        // lo must be up for a route to install.
+        in_netns_thread(ns_fd, || {
+            block_on_netlink(|h| async move {
+                let lo = link_index_by_name(&h, "lo").await?;
+                h.link().set(lo).up().execute().await.into_diagnostic()?;
+                Ok(())
+            })
+        })
+        .unwrap();
+
+        let cidr: ipnet::IpNet = "fd00:dead:beef::/48".parse().unwrap();
+        replace_route_dev_lo_in_netns(ns_fd, cidr).expect("route replace");
+
+        let routes = dump_route_prefixes_in_netns(ns_fd, true).expect("dump v6");
+        assert!(
+            routes.contains(&cidr),
+            "installed route must appear in dump"
+        );
+        let _ = destroy_netns("nl-test-route", ns_fd);
+    }
+}


### PR DESCRIPTION
## Summary

The privileged supervisor builds the sandbox network namespace by shelling out to `ip` (32 call sites) and, for in-namespace operations, `nsenter` — both resolved from the **workload image**. A bare `docker.io/library/alpine:3.22` image ships only busybox `ip` (no `netns` subcommand), so proxy-mode setup fails with `Network namespace creation failed … iproute2 is installed`.

This change programs the namespace entirely through kernel interfaces, so the supervisor needs no network tooling from the workload image:

- **veth pair, addresses, link up/down, routes** are programmed over route netlink (`rtnetlink`).
- The **namespace is created with `unshare(CLONE_NEWNET)`** on a short-lived thread and bind-mounted onto `netns_path` via `mount(2)` (not `ip netns add`), so it persists and stays reachable for the still-`nsenter`-based nft path.
- **In-namespace operations** run on a dedicated thread that `setns()` into the namespace, instead of spawning `nsenter`.

`rtnetlink` is async; it is confined to the new `netns/netlink.rs` module and driven from the synchronous `create()` via a local `current_thread` runtime **on a dedicated OS thread** — `create()` runs inside a tokio runtime on the Podman driver, so building the runtime on the caller thread would panic (“Cannot start a runtime from within a runtime”).

Scope is the `ip`/`nsenter` namespace-setup path only. The `nft` bypass-rule path (still `nsenter`-based) and `dmesg`→NFLOG are separate follow-ups, so `nsenter` and the nft helpers are intentionally left in place.

## Related Issue

Refs #3281 — networking (`ip`/`nsenter`) subset of #2750 (make the privileged supervisor independent of workload-image tooling). Unblocks the bare-Alpine default in #3116.

## Changes

- Add `crates/openshell-supervisor-process/src/netns/netlink.rs`: FD-owned namespace creation, host-side veth setup, setns-thread in-namespace configuration, veth/namespace teardown, and route replace/dump — all over `rtnetlink` + `unshare`/`setns`/`mount`.
- Rewire `NetworkNamespace::create()`, `Drop`, `install_transparent_tcp_rules`, and `validate_synthetic_pool_routes` onto the new module; `first_route_overlap` now operates on parsed route prefixes.
- Remove the dead `run_ip` / `run_ip_netns` / `run_ip_netns_output` helpers and `IP_SEARCH_PATHS`; drop the `iproute2` hint from the proxy-mode error message.
- Add `rtnetlink`, `netlink-packet-route`, and `futures-util` under the crate’s `cfg(target_os = "linux")` dependencies.

## Testing

- Built the supervisor **musl-static** (`x86_64-unknown-linux-musl`) with the new dependencies.
- End-to-end on a rootless-Podman host: a bare `docker.io/library/alpine:3.22` sandbox starts in proxy mode with the network namespace, veth pair, addresses, and default route established via netlink and **no `ip`/`nsenter` process spawned**; the FD-owned namespace bind mount is present, and teardown removes the veth and namespace. The sandbox reaches `Ready`/healthy.
- Root-only integration tests for the netlink primitives are included (gated with `#[ignore]`; require `CAP_NET_ADMIN`).
- No behavior change for images that already ship `iproute2`/`nftables`.

## Checklist

- [x] Conventional commit, signed off (DCO)
- [x] Scoped to the issue; `nft`/`dmesg` paths left for follow-ups
- [x] Supervisor stays musl-static (dependencies are pure Rust)
- [x] No behavior change for images shipping `iproute2`/`nftables`
- [ ] Maintainer review
