### PR TITLE
fix(ci): restore Windows test portability

### DIFF
--- a/crates/openshell-core/src/driver_utils.rs
+++ b/crates/openshell-core/src/driver_utils.rs
@@ -1248,6 +1248,7 @@ mod tests {
         assert!(validate_guest_spiffe_tcp_endpoint("unix:/run/spire/agent.sock", true).is_err());
     }
 
+    #[cfg(unix)]
     #[test]
     fn credential_file_rejects_fifo_without_hanging() {
         // A FIFO with no writer would block a blocking open() forever. The

--- a/crates/openshell-ocsf/tests/event_identity.rs
+++ b/crates/openshell-ocsf/tests/event_identity.rs
@@ -68,7 +68,12 @@ fn device_identifies_the_sandbox_environment() {
 
     assert_eq!(json["device"]["type_id"], 99);
     assert_eq!(json["device"]["type"], "Sandbox");
-    assert_eq!(json["device"]["os"]["name"], "Linux");
+    let expected_os = if cfg!(target_os = "windows") {
+        "Windows"
+    } else {
+        "Linux"
+    };
+    assert_eq!(json["device"]["os"]["name"], expected_os);
 }
 
 #[test]

--- a/tasks/rust.toml
+++ b/tasks/rust.toml
@@ -13,6 +13,7 @@ hide = true
 ["rust:lockfiles:check"]
 description = "Verify all tracked Cargo lockfiles are current"
 run = "tasks/scripts/check-cargo-lockfiles.sh"
+run_windows = "echo Skipping rust:lockfiles:check: Cargo lockfile validation uses a Unix shell helper."
 hide = true
 
 ["rust:lint"]

--- a/tasks/typescript.toml
+++ b/tasks/typescript.toml
@@ -25,6 +25,7 @@ run = "npm run gen"
 description = "Lint proto/ with buf (repo-level buf.yaml)"
 depends = ["sdk:ts:install"]
 run = "./sdk/typescript/node_modules/.bin/buf lint"
+run_windows = "sdk\\typescript\\node_modules\\.bin\\buf.cmd lint"
 
 ["sdk:ts:typecheck"]
 description = "Type-check the TypeScript SDK"


### PR DESCRIPTION
## Summary

Restore portability of two tests that broke the advisory Windows MSVC checks on `main`, and make Unix-specific pre-commit tasks behave correctly under native Windows.

The regressions were introduced by:

- #3015 changed OCSF device identity to use the current host OS but left an integration test expecting Linux unconditionally.
- #2814 inserted a new test between `#[cfg(unix)]` and the FIFO test, leaving the `nix`-dependent FIFO test enabled on Windows.

## Related Issue

No issue required: this is an obvious localized correction to two test regressions and their native-Windows validation path.

## Changes

- Expect the OCSF device OS name to match the build platform.
- Restore the Unix-only guard on the FIFO test that uses `nix::unistd::mkfifo`.
- Explicitly skip the Unix shell-based Cargo lockfile check on native Windows.
- Use npm's Windows `buf.cmd` shim for `proto:lint`.

## Testing

- [x] `mise run pre-commit` completes on native Windows
- [x] `mise run windows:test:x64` (3,540 passed, 16 skipped)
- [x] Native Windows Rust lint, including the e2e and example manifests
- [ ] E2E tests added/updated (not applicable; test and task portability fixes)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)