### PR TITLE
test(supervisor-network): show response body on ssrf_denied assertion failure

### DIFF
--- a/crates/openshell-supervisor-network/src/proxy.rs
+++ b/crates/openshell-supervisor-network/src/proxy.rs
@@ -11023,7 +11023,10 @@ network_policies:
             response.starts_with("HTTP/1.1 403 Forbidden"),
             "internal forward destination must get the SSRF 403; got: {response:?}"
         );
-        assert!(response.contains("ssrf_denied"));
+        assert!(
+            response.contains("ssrf_denied"),
+            "expected the SSRF-specific denial body; got: {response:?}"
+        );
         assert!(
             response.contains("GET 127.0.0.1:80 blocked: declared endpoint check failed"),
             "an explicit loopback endpoint must fail declared-endpoint validation; got: {response:?}"


### PR DESCRIPTION
## Summary

`forward_handler_preserves_ssrf_response_and_denial_stage`'s `ssrf_denied` assertion is the only one in the test without a failure message, unlike its sibling assertions which all print the response body on failure. This test has been failing intermittently in a downstream RPM build's CI, and there was no way to see what response was actually returned, since that's exactly what the missing message would have surfaced.

## Related Issue

No issue required — this is a small, localized test-diagnostics fix with no behavior change.

## Changes

- Added a failure message (`"expected the SSRF-specific denial body; got: {response:?}"`) to the `response.contains("ssrf_denied")` assertion in `forward_handler_preserves_ssrf_response_and_denial_stage`, matching the pattern already used by the other assertions in the same test.

## Testing

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo check -p openshell-supervisor-network --tests` compiles cleanly
- [ ] Full test suite run delegated to CI (this test is intermittently failing in a downstream build; the point of this change is to capture the actual response body on the next failure for root-causing)

## Checklist

- [x] Follows Conventional Commits
- [x] Commits are signed off (DCO)