### PR TITLE
fix(mise): run mise lock --platform linux-x64

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -134,6 +134,18 @@ checksum = "sha256:b8514ed7552e148b0a032114f745118dcb801791adafafeaf9935e4bfb0ed
 url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060720"
 
+[[tools."github:mozilla/sccache"]]
+version = "0.16.0"
+backend = "github:mozilla/sccache"
+
+[tools."github:mozilla/sccache".options]
+asset_pattern = "sccache-v*x86_64*linux*.tar.gz"
+
+[tools."github:mozilla/sccache"."platforms.linux-x64"]
+checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
+
 [[tools."github:nextest-rs/nextest"]]
 version = "cargo-nextest-0.9.143"
 backend = "github:nextest-rs/nextest"


### PR DESCRIPTION
`mise lock --platform linux-x64` records Linux x64 tool resolutions in mise.lock so that linux/amd64 machines can run `mise install --locked` without trying to resolve any tools at runtime.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
