### PR TITLE
fix(ci): restore mise run ci on macOS

### DIFF
--- a/deploy/rpm/migrate-gateway-config.sh
+++ b/deploy/rpm/migrate-gateway-config.sh
@@ -27,7 +27,9 @@ if [ -L "$destination" ] || { [ -e "$destination" ] && [ ! -f "$destination" ]; 
 fi
 
 if [ ! -e "$destination" ]; then
-    install -Dm 0644 "$current_default" "$destination"
+    destination_dir=$(dirname "$destination")
+    mkdir -p "$destination_dir"
+    install -m 0644 "$current_default" "$destination"
     exit 0
 fi
 

--- a/e2e/parity/run.sh
+++ b/e2e/parity/run.sh
@@ -290,11 +290,13 @@ supervisor_target_triple() {
 build_supervisor() {
   local variant=$1 source_root=$2 target_dir=$3 override=$4 output_var=$5
   local binary target jobs=()
-  target="$(supervisor_target_triple)"
   target_dir="${target_dir:-${ROOT}/target/parity/${variant}}"
   case "${target_dir}" in /*) ;; *) target_dir="${ROOT}/${target_dir}" ;; esac
-  binary="${override:-${target_dir}/${target}/release/openshell-sandbox}"
-  if [ -z "${override}" ]; then
+  if [ -n "${override}" ]; then
+    binary="${override}"
+  else
+    target="$(supervisor_target_triple)"
+    binary="${target_dir}/${target}/release/openshell-sandbox"
     require_clean_source "${variant}" "${source_root}"
     if [ -n "${CARGO_BUILD_JOBS:-}" ]; then jobs=(-j "${CARGO_BUILD_JOBS}"); fi
     echo "Building ${variant} supervisor in ${target_dir}..."

--- a/e2e/parity/test.sh
+++ b/e2e/parity/test.sh
@@ -8,7 +8,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openshell-parity-test.XXXXXX")"
+TMP_ROOT="${TMPDIR:-/tmp}"
+TMP_ROOT="${TMP_ROOT%/}"
+WORKDIR="$(mktemp -d "${TMP_ROOT}/openshell-parity-test.XXXXXX")"
 trap 'rm -rf "${WORKDIR}"' EXIT
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/e2e/support/podman-gateway-config.sh
+++ b/e2e/support/podman-gateway-config.sh
@@ -128,9 +128,12 @@ e2e_write_podman_gateway_config() {
         # A remote UDS driver owns all runtime options. Keep the selected
         # gateway table transport-only so no in-tree setting can be mistaken
         # for executed external-driver configuration.
-        sed -i '/^health_check_interval_secs = /d' "${output}"
+        sed '/^health_check_interval_secs = /d' "${output}" >"${output}.updated"
+        mv "${output}.updated" "${output}"
       elif [ "${option_profile}" = "podman-options" ]; then
-        sed -i 's/^health_check_interval_secs = .*/health_check_interval_secs = 7/' "${output}"
+        sed 's/^health_check_interval_secs = .*/health_check_interval_secs = 7/' \
+          "${output}" >"${output}.updated"
+        mv "${output}.updated" "${output}"
       fi
       # The v2 template opens the Podman table. Insert gateway-owned TLS
       # before it rather than reopening [openshell.gateway] later.

--- a/tasks/python.toml
+++ b/tasks/python.toml
@@ -60,5 +60,6 @@ hide = true
 
 ["python:proto"]
 description = "Generate Python protobuf stubs from .proto files"
+env = { SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENSHELL = "0.0.0" }
 run = "uv run --frozen python tasks/scripts/generate_python_proto.py"
 hide = true

--- a/tasks/scripts/stage-prebuilt-binaries.sh
+++ b/tasks/scripts/stage-prebuilt-binaries.sh
@@ -149,7 +149,9 @@ patch_workspace_version() {
   cargo_toml_backup="$(mktemp)"
   cp "$cargo_toml" "$cargo_toml_backup"
   restore_cargo_toml=1
-  sed -i -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' "$cargo_toml"
+  sed -E '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*".*"/version = "'"${OPENSHELL_CARGO_VERSION}"'"/}' \
+    "$cargo_toml" >"${cargo_toml}.updated"
+  mv "${cargo_toml}.updated" "$cargo_toml"
 }
 
 restore_workspace_version() {

--- a/tasks/scripts/test-gateway-config.sh
+++ b/tasks/scripts/test-gateway-config.sh
@@ -23,12 +23,11 @@ printf '%s\n' 'import sys, tomllib' 'from pathlib import Path' 'assert tomllib.l
 mkdir -p "${WORK}/bin"
 ln -s /usr/bin/true "${WORK}/bin/mise"
 ln -s /usr/bin/false "${WORK}/bin/lsof"
-ln -s /bin/bash "${WORK}/bin/gateway"
-
-printf '%s\n' 'exec() {' '  config=""' '  while [ "$#" -gt 0 ]; do' '    if [ "$1" = "--config" ]; then config="$2"; shift 2; else shift; fi' '  done' '  cp "${config}" "${CAPTURED_CONFIG}"' '  builtin exit 0' '}' > "${WORK}/fake-gateway-env"
+printf '%s\n' '#!/usr/bin/env bash' 'config=""' 'while [ "$#" -gt 0 ]; do' '  if [ "$1" = "--config" ]; then config="$2"; shift 2; else shift; fi' 'done' 'if [ -n "${config}" ]; then cp "${config}" "${CAPTURED_CONFIG}"; fi' > "${WORK}/bin/gateway"
+chmod +x "${WORK}/bin/gateway"
 
 CAPTURED_CONFIG="${WORK}/generated.toml"
-BASH_ENV="${WORK}/fake-gateway-env" CAPTURED_CONFIG="${CAPTURED_CONFIG}" PATH="${WORK}/bin:${PATH}" KUBERNETES_SERVICE_HOST=fixture OPENSHELL_GATEWAY_BIN=/bin/true OPENSHELL_GATEWAY_STATE_DIR="${WORK}/state" OPENSHELL_SANDBOX_IMAGE_PULL_POLICY=IfNotPresent OPENSHELL_GRPC_ENDPOINT=https://callback.example.test:9443 bash "${ROOT}/tasks/scripts/gateway.sh"
+CAPTURED_CONFIG="${WORK}/generated.toml" PATH="${WORK}/bin:${PATH}" KUBERNETES_SERVICE_HOST=fixture OPENSHELL_GATEWAY_BIN="${WORK}/bin/gateway" OPENSHELL_GATEWAY_STATE_DIR="${WORK}/state" OPENSHELL_SANDBOX_IMAGE_PULL_POLICY=IfNotPresent OPENSHELL_GRPC_ENDPOINT=https://callback.example.test:9443 bash "${ROOT}/tasks/scripts/gateway.sh"
 
 printf '%s\n' 'import sys, tomllib' 'from pathlib import Path' 'config = tomllib.loads(Path(sys.argv[1]).read_text())' 'gateway = config["openshell"]["gateway"]' 'driver = config["openshell"]["drivers"]["kubernetes"]' 'assert config["openshell"]["version"] == 2' 'assert gateway["compute_driver"] == "kubernetes"' 'assert "compute_drivers" not in gateway' 'assert driver["image_pull_policy"] == "if_not_present"' 'assert driver["grpc_endpoint"] == "https://callback.example.test:9443"' > "${WORK}/check_generated.py"
 "${UV}" run --no-project python "${WORK}/check_generated.py" "${CAPTURED_CONFIG}"


### PR DESCRIPTION
- Replace BSD-incompatible in-place sed calls with portable temp-file rewrites.
- Remove test-only shell interception and capture generated gateway config directly.
- Allow parity tests to use supplied supervisor binaries without resolving a Linux target.
- Normalize temporary-directory paths and use portable RPM config installation.
- Set a valid setuptools-scm version for Python protobuf generation in Jujutsu checkouts.

I tested that this branch works on linux/amd64 by running `mise run ci` in an OpenShell sandbox.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!--
Required for features, user-visible behavior changes, public API changes,
architecture changes, and multi-PR efforts: Fixes #NNN or Closes #NNN.
For an exempt small docs fix, mechanical change, or obvious localized bug fix:
No issue required: <brief reason>
-->

## Changes
<!-- Bullet list of key changes -->

## Testing
<!-- Report current verification performed for this implementation. Do not copy diagnostics from the original issue. -->
- [ ] `mise run pre-commit` passes
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

## Checklist
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Commits are signed off (DCO)
- [ ] Architecture docs updated (if applicable)
